### PR TITLE
Removed <span> tags from verses when inserting into VDB

### DIFF
--- a/ai/vdb/milvus_db.py
+++ b/ai/vdb/milvus_db.py
@@ -225,7 +225,10 @@ class VectorDatabase:
                             if "header_" in verse:
                                 continue
                             verse_numbers.append(int(verse))
-                            verse_texts.append(json_data[verse])
+                            verse_clean_text = json_data[verse]
+                            # Remove the HTML tags to have cleaner database entries
+                            verse_clean_text = verse_clean_text.replace("<span class=\"wj\">", "").replace("</span>", "").strip()
+                            verse_texts.append(verse_clean_text)
                         verse_embeddings = self.embedding_engine.embed(verse_texts, prompt_type="document", normalize=False)
 
                         data = []

--- a/scripts/search_milvus_db_async.py
+++ b/scripts/search_milvus_db_async.py
@@ -33,7 +33,7 @@ async def main():
     logger.info(await vector_database.list_collections_in_database())
 
     collection_name = "bsb"
-    queries = ["In the beginning", "Sodom and Gomorrah", "Garden of Eden", "Tower of Babel", "Adam and Eve", "What was the name of the first man?", "Noah's Arc", "Noah's Ark"]
+    queries = ["In the beginning", "Sodom and Gomorrah", "Garden of Eden", "Tower of Babel", "Adam and Eve", "What was the name of the first man?", "Noah's Arc", "Noah's Ark", "For God so loves the world", "Jesus said"]
     limit = 10
     for query in queries:
         # Get results

--- a/scripts/search_milvus_db_sync.py
+++ b/scripts/search_milvus_db_sync.py
@@ -36,7 +36,7 @@ def main():
     logger.info(vector_database.list_collections_in_database())
 
     collection_name = "bsb"
-    queries = ["In the beginning", "Sodom and Gomorrah", "Garden of Eden", "Tower of Babel", "Adam and Eve", "What was the name of the first man?", "Noah's Arc", "Noah's Ark"]
+    queries = ["In the beginning", "Sodom and Gomorrah", "Garden of Eden", "Tower of Babel", "Adam and Eve", "What was the name of the first man?", "Noah's Arc", "Noah's Ark", "For God so loves the world", "Jesus said"]
     limit = 10
     for query in queries:
         # Get results


### PR DESCRIPTION
Remove `<span class=\"wj\">` and `</span>` tags to keep the VDB clean so more relevant information can be retrieved.