### PR TITLE
Migrate MinIO to SeaweedFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The current version of Nvidia 580.XX breaks and no longer supports legacy mode. 
 - SGLang - https://github.com/sgl-project/sglang
 #### Other
 - etcd (Milvus metadata storage) - https://github.com/etcd-io/etcd
-- MinIO (persistant storage for large-scale files) - https://github.com/minio/minio
+- SeaweedFS (S3-compatible database) - https://github.com/seaweedfs/seaweedfs
 
 ## Licensing
 fAIth is released under the GNU General Public License v3.0 (GPLv3). We believe that just as God's Word is a gift freely given to all, the tools used to interact with it should remain free for everyone to use, study, and share.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   etcd:
-    container_name: milvus-etcd-faith
+    container_name: etcd-faith
     image: milvusdb/etcd:latest
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
@@ -36,21 +36,116 @@ services:
       timeout: 30s
       retries: 5
 
-  minio:
-    container_name: milvus-minio-faith
-    image: minio/minio:latest
-    environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
-      MINIO_LOG_LEVEL: warn
+  seaweedfs-master:
+    container_name: seaweedfs-master-faith
+    image: chrislusf/seaweedfs:4.03
+    ports:
+      - 9333:9333
+      - 19333:19333
+      - 9324:9324
+    command: 'master -ip=seaweedfs-master -ip.bind=0.0.0.0 -metricsPort=9324 -mdir=/data'
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
-    command: minio server /minio_data
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/seaweedfs/master:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:9333/cluster/status"]
       interval: 30s
       timeout: 30s
       retries: 5
+
+  seaweedfs-volume:
+    container_name: seaweedfs-volume-faith
+    image: chrislusf/seaweedfs:4.03
+    ports:
+      - 8080:8080
+      - 18080:18080
+      - 9325:9325
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/seaweedfs/volume:/data
+    command: 'volume -ip=seaweedfs-volume -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325 -dir=/data'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+    depends_on:
+      seaweedfs-master:
+        condition: service_healthy
+
+  seaweedfs-filer:
+    container_name: seaweedfs-filer-faith
+    image: chrislusf/seaweedfs:4.03
+    ports:
+      - 8888:8888
+      - 18888:18888
+      - 9326:9326
+    command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+    tty: true
+    stdin_open: true
+    depends_on:
+      seaweedfs-master:
+        condition: service_healthy
+      seaweedfs-volume:
+        condition: service_healthy
+
+  seaweedfs-s3:
+    container_name: seaweedfs-s3-faith
+    image: chrislusf/seaweedfs:4.03
+    ports:
+      - 8333:8333
+      - 9327:9327
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+    command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8333/"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+    depends_on:
+      seaweedfs-master:
+        condition: service_healthy
+      seaweedfs-volume:
+        condition: service_healthy
+      seaweedfs-filer:
+        condition: service_healthy
+
+  seaweedfs-init:
+    container_name: seaweedfs-init-faith
+    image: amazon/aws-cli:latest
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_DEFAULT_REGION: us-east-1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Waiting for SeaweedFS S3 to be ready..."
+        until aws --endpoint-url=http://seaweedfs-s3:8333 s3 ls 2>/dev/null; do
+          echo "SeaweedFS S3 not ready yet, waiting..."
+          sleep 2
+        done
+        echo "Checking if milvus-bucket exists..."
+        if aws --endpoint-url=http://seaweedfs-s3:8333 s3api head-bucket --bucket milvus-bucket 2>/dev/null; then
+          echo "Bucket milvus-bucket already exists"
+        else
+          echo "Creating milvus-bucket..."
+          if aws --endpoint-url=http://seaweedfs-s3:8333 s3 mb s3://milvus-bucket; then
+            echo "Bucket milvus-bucket created successfully"
+          else
+            echo "ERROR: Failed to create bucket milvus-bucket. Try: docker compose down -v && sudo rm -rf ./volumes"
+            exit 1
+          fi
+        fi
+        echo "Bucket initialization complete"
+    depends_on:
+      seaweedfs-s3:
+        condition: service_healthy
 
   milvus:
     container_name: milvus-faith
@@ -59,7 +154,12 @@ services:
       - "19530:19530"
     environment:
       ETCD_ENDPOINTS: etcd:2379
-      MINIO_ADDRESS: minio:9000
+      MINIO_ADDRESS: seaweedfs-s3:8333
+      MINIO_ACCESS_KEY_ID: minioadmin
+      MINIO_SECRET_ACCESS_KEY: minioadmin
+      MINIO_USE_SSL: "false"
+      MINIO_BUCKET_NAME: milvus-bucket
+      MINIO_ROOT_PATH: milvus/data
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
     command: ["milvus", "run", "standalone"]
@@ -74,14 +174,16 @@ services:
     depends_on:
       etcd:
         condition: service_healthy
-      minio:
+      seaweedfs-s3:
         condition: service_healthy
+      seaweedfs-init:
+        condition: service_completed_successfully
       embedding:
         condition: service_healthy
 
   embedding:
     container_name: llama-cpp-embedding-faith
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ghcr.io/ggml-org/llama.cpp:server
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     ports:
@@ -97,17 +199,10 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
 
   llm:
     container_name: llama-cpp-llm-faith
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ghcr.io/ggml-org/llama.cpp:server
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     ports:
@@ -123,13 +218,6 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
 
   webapp:
     build:


### PR DESCRIPTION
MinIO is now in maintenance mode (https://charts.min.io/) and is no longer providing new updates except for crucial security patches. MinIO is also no longer providing new Docker images, as users are now expected to build any new versions of the application themselves from source. fAIth does not expect its users to build its underlying applications and containers from source, and we much rather use and pull projects that are actively and well maintained. 

With that being said, this PR migrates the S3-compatible database from MinIO to SeaweedFS (https://github.com/seaweedfs/seaweedfs) for Milvus. SeaweedFS is touted for its speed, especially for smaller files (like individual Bible verses), is battle tested with over 10 years of usage, is well maintained, and is free under the Apache license.