### PR TITLE
Improve Docker Security

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -6,7 +6,7 @@ UVICORN_WORKERS = "1"
 
 # ---------- DJANGO CONFIG ---------- #
 DJANGO_DEBUG = False # Set to True for development, False for production
-DJANGO_SECRET_KEY = "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(" # Change this to a strong secret key!
+DJANGO_SECRET_KEY = "CHANGE_ME_use_a_long_random_string" # Generate with: python -c "import secrets; print(secrets.token_urlsafe(50))"
 DJANGO_ALLOWED_HOSTS = ["127.0.0.1", "localhost"] # List of allowed hosts
 
 
@@ -29,7 +29,7 @@ HF_TOKEN = ""
 POSTGRES_HOST = "" # Can be an external PostgreSQL endpoint (e.g., postgresql-instance.com or 192.168.1.100). DO NOT include port here; use POSTGRES_PORT instead. If using a local PostgreSQL service, can leave empty.
 POSTGRES_PORT = "5432" # Only used if POSTGRES_HOST is set (for external databases). For local postgres, port 5432 is always used.
 POSTGRES_USER = "faith_user"
-POSTGRES_PASSWORD = "postgres-secure-password" # Use a strong password!
+POSTGRES_PASSWORD = "CHANGE_ME_use_a_strong_password" # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 POSTGRES_DATABASE = "faith_db"
 
 
@@ -40,7 +40,7 @@ MILVUS_HOST = "" # Can be an external Milvus endpoint (e.g., milvus-instance.com
 MILVUS_PORT = "19530" # Only used if MILVUS_HOST is set (for external databases). For local Milvus, port 19530 is always used.
 MILVUS_DATABASE_NAME = "fAIth"
 MILVUS_USERNAME = "root"
-MILVUS_PASSWORD = "Milvus"
+MILVUS_PASSWORD = "CHANGE_ME_use_a_strong_password" # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 
 # Database Configuration
 # DATABASE_TYPE = "dense" # Use only vector embeddings with your embedding model
@@ -72,7 +72,6 @@ EMBEDDING_MAX_CONTEXT_LENGTH = 4096 # The maximum context length you want to all
 # EMBEDDING_MODEL_RUNNER = "vllm"
 EMBEDDING_MODEL_RUNNER = "llama_cpp"
 # EMBEDDING_MODEL_RUNNER = "ollama"
-# EMBEDDING_MODEL_RUNNER = "docker_model_runner"
 # EMBEDDING_MODEL_RUNNER = "sglang"
 
 # GPU Type
@@ -113,7 +112,6 @@ LLM_MAX_CONTEXT_LENGTH = 4096 # The maximum context length you want to allow for
 # LLM_MODEL_RUNNER = "vllm"
 LLM_MODEL_RUNNER = "llama_cpp"
 # LLM_MODEL_RUNNER = "ollama"
-# LLM_MODEL_RUNNER = "docker_model_runner"
 # LLM_MODEL_RUNNER = "sglang"
 
 # GPU Type

--- a/.env_template
+++ b/.env_template
@@ -26,7 +26,7 @@ HF_TOKEN = ""
 
 # ---------- POSTGRESQL CONFIG ---------- #
 # Database credentials
-POSTGRES_HOST = "" # Can be an external PostgreSQL endpoint (e.g., postgresql-instance.com). If using a local PostgreSQL service, can leave empty.
+POSTGRES_HOST = "" # Can be an external PostgreSQL endpoint (e.g., postgresql-instance.com or 192.168.1.100). DO NOT include port here; use POSTGRES_PORT instead. If using a local PostgreSQL service, can leave empty.
 POSTGRES_PORT = "5432" # Only used if POSTGRES_HOST is set (for external databases). For local postgres, port 5432 is always used.
 POSTGRES_USER = "faith_user"
 POSTGRES_PASSWORD = "postgres-secure-password" # Use a strong password!
@@ -36,8 +36,8 @@ POSTGRES_DATABASE = "faith_db"
 
 # ---------- MILVUS ---------- #
 # Database credentials
-MILVUS_URL = "" # Can be an external Milvus endpoint (e.g., http://milvus-instance.com). If using a local Milvus service, can leave empty.
-# The default Milvus port (19530) will be used if MILVUS_URL is not set in order to not require exposing the port.
+MILVUS_HOST = "" # Can be an external Milvus endpoint (e.g., milvus-instance.com or 192.168.1.100). DO NOT include http://, https://, or port here; use MILVUS_PORT instead. If using a local Milvus service, can leave empty.
+MILVUS_PORT = "19530" # Only used if MILVUS_HOST is set (for external databases). For local Milvus, port 19530 is always used.
 MILVUS_DATABASE_NAME = "fAIth"
 MILVUS_USERNAME = "root"
 MILVUS_PASSWORD = "Milvus"

--- a/.env_template
+++ b/.env_template
@@ -6,7 +6,7 @@ UVICORN_WORKERS = "1"
 
 # ---------- DJANGO CONFIG ---------- #
 DJANGO_DEBUG = False # Set to True for development, False for production
-DJANGO_SECRET_KEY = "CHANGE_ME_use_a_long_random_string" # Generate with: python -c "import secrets; print(secrets.token_urlsafe(50))"
+DJANGO_SECRET_KEY = "CHANGE_ME_use_a_long_secret_key" # Generate with: python -c "import secrets; print(secrets.token_urlsafe(64))"
 DJANGO_ALLOWED_HOSTS = ["127.0.0.1", "localhost"] # List of allowed hosts
 
 

--- a/.env_template
+++ b/.env_template
@@ -1,6 +1,6 @@
 # ---------- WEBAPP CONFIG ---------- #
-WEBAPP_PORT = 8000
-UVICORN_WORKERS = 1
+WEBAPP_PORT = "8000"
+UVICORN_WORKERS = "1"
 
 
 
@@ -25,8 +25,9 @@ HF_TOKEN = ""
 
 
 # ---------- POSTGRESQL CONFIG ---------- #
-POSTGRES_HOST = "localhost"
-POSTGRES_PORT = 5432
+# Database credentials
+POSTGRES_HOST = "" # Can be an external PostgreSQL endpoint (e.g., postgresql-instance.com). If using a local PostgreSQL service, can leave empty.
+POSTGRES_PORT = "5432" # Only used if POSTGRES_HOST is set (for external databases). For local postgres, port 5432 is always used.
 POSTGRES_USER = "faith_user"
 POSTGRES_PASSWORD = "postgres-secure-password" # Use a strong password!
 POSTGRES_DATABASE = "faith_db"
@@ -34,34 +35,32 @@ POSTGRES_DATABASE = "faith_db"
 
 
 # ---------- MILVUS ---------- #
-MILVUS_URL = "http://localhost"
-MILVUS_PORT = 19530
+# Database credentials
+MILVUS_URL = "" # Can be an external Milvus endpoint (e.g., http://milvus-instance.com). If using a local Milvus service, can leave empty.
+# The default Milvus port (19530) will be used if MILVUS_URL is not set in order to not require exposing the port.
 MILVUS_DATABASE_NAME = "fAIth"
 MILVUS_USERNAME = "root"
 MILVUS_PASSWORD = "Milvus"
-MILVUS_SEARCH_LIMIT = 10
 
-# Use only vector embeddings with your embedding model
-# DATABASE_TYPE = "dense"
-# Use only lexical search with BM25
-# DATABASE_TYPE = "sparse"
-# Use both vector embeddings and lexical search
-DATABASE_TYPE = "hybrid"
-
+# Database Configuration
+# DATABASE_TYPE = "dense" # Use only vector embeddings with your embedding model
+# DATABASE_TYPE = "sparse" # Use only lexical search with BM25
+DATABASE_TYPE = "hybrid" # Use both vector embeddings and lexical search
 # How much influence the vector embeddings and lexical search has on the overall results
 # Only available when using "hybrid" search
 DENSE_WEIGHT = 0.8
 SPARSE_WEIGHT = 0.2
+MILVUS_SEARCH_LIMIT = 10
 
 
 
 # ---------- EMBEDDING MODEL ---------- #
 # Endpoints
-BASE_EMBEDDING_URL = ""
+BASE_EMBEDDING_URL = "" # Can be an external embedding endpoint (e.g., http://embedding-instance.com). If using a local embedding service, can leave empty.
 EMBEDDING_API_KEY = "" # Should be set to the API key you want to use for the embedding model. If using local models, can leave empty. If using remote models, should be set to the API key for the service you are using.
 
 # Localhost options
-EMBEDDING_PORT = "11435" # NOTE: IF THIS IS SET, IT WILL OVERRIDE THE BASE_EMBEDDING_URL TO USE THE LOCALHOST ENDPOINT. MAKE THIS EMPTY IF USING A REMOTE EMBEDDING SERVICE.
+EMBEDDING_PORT = "11435" # NOTE: If using a local embedding, this MUST be set to the port you want to use for the embedding service. If using a remote embedding service, this can be left empty.
 
 # Embedding Model
 EMBEDDING_MODEL_ID = "Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0" # The model ID you want to use for the embedding model
@@ -99,11 +98,11 @@ EMBEDDING_VLLM_ENFORCE_EAGER = False
 
 # ---------- LLM MODEL ---------- #
 # Endpoints
-BASE_LLM_URL = ""
+BASE_LLM_URL = "" # Can be an external LLM endpoint (e.g., http://llm-instance.com). If using a local LLM service, can leave empty.
 LLM_API_KEY = "" # Should be set to the API key you want to use for the LLM model. If using local models, can leave empty. If using remote models, should be set to the API key for the service you are using.
 
 # Localhost options
-LLM_PORT = "11436" # NOTE: IF THIS IS SET, IT WILL OVERRIDE THE BASE_LLM_URL TO USE THE LOCALHOST ENDPOINT. MAKE THIS EMPTY IF USING A REMOTE LLM SERVICE.
+LLM_PORT = "11436" # NOTE: If using a local LLM, this MUST be set to the port you want to use for the LLM service. If using a remote LLM service, this can be left empty.
 
 # LLM Model
 LLM_MODEL_ID = "unsloth/Qwen3.5-4B-GGUF:Q4_K_M" # The model ID you want to use for the LLM model

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,5 +26,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Check Django System
+      env:
+        DJANGO_SECRET_KEY: "secret_key"
+        POSTGRES_PASSWORD: "password"
+        MILVUS_PASSWORD: "password"
       run: |
         python manage.py check

--- a/README.md
+++ b/README.md
@@ -29,13 +29,24 @@ sudo nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi && sud
 3. Activate the venv with `.venv/bin/activate`
 4. Install required packages with `pip install -r requirements.txt`
 5. Copy `.env_template` to `.env`
-6. Edit `.env` to fit your environment
+6. Change `DJANGO_SECRET_KEY`, `POSTGRES_PASSWORD`, and `MILVUS_PASSWORD` in the new `.env` file to use more secure secrets. You can generate secure values with:
+   - `DJANGO_SECRET_KEY`: `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+   - `POSTGRES_PASSWORD` and `MILVUS_PASSWORD`: `python -c "import secrets; print(secrets.token_urlsafe(32))"`
+7. If you wish to host fAIth on your local network, add your local IP to the `DJANGO_ALLOWED_HOSTS` list
+8. Configure the remaining `.env` settings to fit your environment:
+   - **AI Models**: Set `EMBEDDING_MODEL_ID` and `LLM_MODEL_ID` based on your available memory
+   - **Model Serving** - Choose one approach:
+     - **Local Models**: Set `EMBEDDING_MODEL_RUNNER` and `LLM_MODEL_RUNNER` (vllm, llama_cpp, ollama, or sglang), configure `EMBEDDING_GPU_TYPE` and `LLM_GPU_TYPE` (cpu, nvidia, amd, intel).
+        - **Advanced**: If using llama_cpp, you can adjust `EMBEDDING_LLAMA_CPP_GPU_LAYERS` and `LLM_LLAMA_CPP_GPU_LAYERS` for more fine-grained tuning of where the model lives (-1 for all GPU layers, 0 for CPU-only)
+     - **Third-Party Providers**: Set `BASE_EMBEDDING_URL` and `BASE_LLM_URL` instead, then add API keys `EMBEDDING_API_KEY`, `LLM_API_KEY`, and `HF_TOKEN` as needed
+   - **Webapp Settings**: `WEBAPP_PORT` and `UVICORN_WORKERS`
+   - **Bible Configuration**: `ENABLED_VERSIONS`, `DEFAULT_VERSION`, `DEFAULT_BOOK`, and `DEFAULT_CHAPTER`
 
-**NOTE: Before running fAIth, if you plan to use the default options provided in the `.env` file, please ensure you have at least 6GB of available VRAM or shared system memory to provide ample room for the AI models used. If you do not have at least 6GB of memory, please edit the `.env` file to use models that support your memory size.**
+**NOTE: Before running fAIth, if you plan to use the default options provided in the `.env` file, please ensure you have at least 6GB of available VRAM or shared system memory to provide ample room for the AI models used. If you do not have at least 6GB of memory, please edit the `.env` file to use models that support your memory size or opt for third-party providers instead.**
 
-7. Run the Docker YML generator with `python ./scripts/build_docker_compose.py`
-8. Start fAIth by running `docker compose up -d`. You may want to use this time to grab a coffee and/or read your Bible. This step may take a while. This step involves downloading all of the required Docker containers, downloading the AI models, and loading the vector database. After these steps complete, fAIth should automatically run via uvicorn.
-9. Visit `http://localhost:8000` to access fAIth
+9. Run the Docker Compose generator with `python ./scripts/build_docker_compose.py`
+10. Start fAIth by running `docker compose up -d`. You may want to use this time to grab a coffee and/or read your Bible. This step may take a while. This step involves downloading all of the required Docker containers, downloading the AI models, and loading the vector database. After these steps complete, fAIth should automatically run via uvicorn.
+11. Visit `http://localhost:8000` to access fAIth
 
 ## Credits
 ### Applications

--- a/README.md
+++ b/README.md
@@ -32,21 +32,22 @@ sudo nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi && sud
 6. Change `DJANGO_SECRET_KEY`, `POSTGRES_PASSWORD`, and `MILVUS_PASSWORD` in the new `.env` file to use more secure secrets. You can generate secure values with:
    - `DJANGO_SECRET_KEY`: `python -c "import secrets; print(secrets.token_urlsafe(64))"`
    - `POSTGRES_PASSWORD` and `MILVUS_PASSWORD`: `python -c "import secrets; print(secrets.token_urlsafe(32))"`
-7. If you wish to host fAIth on your local network, add your local IP to the `DJANGO_ALLOWED_HOSTS` list
-8. Configure the remaining `.env` settings to fit your environment:
+7. (Optional) Set `HF_TOKEN` if you wish to use models from HuggingFace that require authentication
+8. If you wish to host fAIth on your local network, add your local IP to the `DJANGO_ALLOWED_HOSTS` list
+9. Configure the remaining `.env` settings to fit your environment:
    - **AI Models**: Set `EMBEDDING_MODEL_ID` and `LLM_MODEL_ID` based on your available memory
    - **Model Serving** - Choose one approach:
      - **Local Models**: Set `EMBEDDING_MODEL_RUNNER` and `LLM_MODEL_RUNNER` (vllm, llama_cpp, ollama, or sglang), configure `EMBEDDING_GPU_TYPE` and `LLM_GPU_TYPE` (cpu, nvidia, amd, intel).
         - **Advanced**: If using llama_cpp, you can adjust `EMBEDDING_LLAMA_CPP_GPU_LAYERS` and `LLM_LLAMA_CPP_GPU_LAYERS` for more fine-grained tuning of where the model lives (-1 for all GPU layers, 0 for CPU-only)
-     - **Third-Party Providers**: Set `BASE_EMBEDDING_URL` and `BASE_LLM_URL` instead, then add API keys `EMBEDDING_API_KEY`, `LLM_API_KEY`, and `HF_TOKEN` as needed
+     - **Third-Party Providers**: Set `BASE_EMBEDDING_URL` and `BASE_LLM_URL` instead, then add API keys `EMBEDDING_API_KEY` and `LLM_API_KEY` as needed
    - **Webapp Settings**: `WEBAPP_PORT` and `UVICORN_WORKERS`
    - **Bible Configuration**: `ENABLED_VERSIONS`, `DEFAULT_VERSION`, `DEFAULT_BOOK`, and `DEFAULT_CHAPTER`
 
 **NOTE: Before running fAIth, if you plan to use the default options provided in the `.env` file, please ensure you have at least 6GB of available VRAM or shared system memory to provide ample room for the AI models used. If you do not have at least 6GB of memory, please edit the `.env` file to use models that support your memory size or opt for third-party providers instead.**
 
-9. Run the Docker Compose generator with `python ./scripts/build_docker_compose.py`
-10. Start fAIth by running `docker compose up -d`. You may want to use this time to grab a coffee and/or read your Bible. This step may take a while. This step involves downloading all of the required Docker containers, downloading the AI models, and loading the vector database. After these steps complete, fAIth should automatically run via uvicorn.
-11. Visit `http://localhost:8000` to access fAIth
+10. Run the Docker Compose generator with `python ./scripts/build_docker_compose.py`
+11. Start fAIth by running `docker compose up -d`. You may want to use this time to grab a coffee and/or read your Bible. This step may take a while. This step involves downloading all of the required Docker containers, downloading the AI models, and loading the vector database. After these steps complete, fAIth should automatically run via uvicorn.
+12. Visit `http://localhost:8000` to access fAIth
 
 ## Credits
 ### Applications

--- a/ai/llm/completions.py
+++ b/ai/llm/completions.py
@@ -2,14 +2,11 @@ import json
 import logging
 import os
 
-from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
 # Set up logging
 logger = logging.getLogger(__name__)
 
-# Load environment variables
-load_dotenv()
 
 
 class Completions:
@@ -21,7 +18,7 @@ class Completions:
 
     Configuration from environment variables:
         - LLM_MODEL_ID: Model identifier (default: "unsloth/Qwen3.5-4B-GGUF:Q4_K_M")
-        - BASE_LLM_URL: Service endpoint (default: http://localhost:11436/v1)
+        - BASE_LLM_URL: Service endpoint (default: http://llm:11436/v1)
         - LLM_MODEL_ARGUMENTS: JSON string of model-specific parameters (default: {} for compatibility with other models that may not share the same parameters)
         - LLM_API_KEY: Authentication key (default: "")
     """
@@ -50,15 +47,11 @@ class Completions:
             self.model_arguments = {}
         logger.info(f"LLM model arguments: {self.model_arguments}")
 
-        # Build service endpoint URL and authentication
-        llm_port = str(os.getenv("LLM_PORT", "")).strip()
-        if llm_port:
-            base_url = f"http://llm:{llm_port}/v1"
-        else:
-            base_url = str(os.getenv("BASE_LLM_URL", "")).strip()
-            if not base_url:
-                logger.error("Base LLM URL is not set")
-                raise ValueError("Base LLM URL is not set")
+        # Use pre-computed LLM URL from docker-compose or environment
+        base_url = str(os.getenv("BASE_LLM_URL", "")).strip()
+        if not base_url:
+            logger.error("Base LLM URL is not set")
+            raise ValueError("Base LLM URL is not set")
         logger.info(f"Base LLM URL: {base_url}")
         
         api_key = str(os.getenv("LLM_API_KEY", "")).strip()

--- a/ai/llm/completions.py
+++ b/ai/llm/completions.py
@@ -34,30 +34,28 @@ class Completions:
             ValueError: If LLM_MODEL_ID is not set.
         """
         # Load and validate LLM model configuration
-        self.model_name = str(os.getenv("LLM_MODEL_ID", "unsloth/Qwen3.5-4B-GGUF:Q4_K_M")).strip()
+        self.model_name = str(os.getenv("LLM_MODEL_ID") or "unsloth/Qwen3.5-4B-GGUF:Q4_K_M").strip()
         if not self.model_name:
             logger.error("LLM model ID is not set")
             raise ValueError("LLM model ID is not set")
         logger.info(f"LLM model ID: {self.model_name}")
 
         # Load optional model-specific parameters (e.g., temperature, top_p, enable_thinking, etc.)
-        self.model_arguments = json.loads(str(os.getenv("LLM_MODEL_ARGUMENTS", "{}")).strip())
+        self.model_arguments = json.loads(str(os.getenv("LLM_MODEL_ARGUMENTS") or "{}").strip())
         if not self.model_arguments:
             logger.warning("LLM model arguments are not set")
-            self.model_arguments = {}
         logger.info(f"LLM model arguments: {self.model_arguments}")
 
         # Use pre-computed LLM URL from docker-compose or environment
-        base_url = str(os.getenv("BASE_LLM_URL", "")).strip()
+        base_url = str(os.getenv("BASE_LLM_URL") or "").strip()
         if not base_url:
             logger.error("Base LLM URL is not set")
             raise ValueError("Base LLM URL is not set")
         logger.info(f"Base LLM URL: {base_url}")
-        
-        api_key = str(os.getenv("LLM_API_KEY", "")).strip()
+
+        api_key = str(os.getenv("LLM_API_KEY") or "").strip()
         if not api_key:
             logger.warning("LLM API key is not set")
-        logger.info(f"LLM API key: {api_key}")
 
         # Initialize async OpenAI-compatible client
         self.client = AsyncOpenAI(base_url=base_url, api_key=api_key)

--- a/ai/tests/llm/test_completions.py
+++ b/ai/tests/llm/test_completions.py
@@ -14,7 +14,7 @@ class TestCompletionsInit(SimpleTestCase):
         """Test that Completions initializes correctly in local mode (LLM_PORT set)."""
         with patch.dict(os.environ, {
             "LLM_MODEL_ID": "test-model",
-            "LLM_PORT": "11436",
+            "BASE_LLM_URL": "http://llm:11436/v1",
             "LLM_API_KEY": "test-key"
         }, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client:
@@ -42,7 +42,7 @@ class TestCompletionsInit(SimpleTestCase):
     
     def test_completions_init_with_default_model_local_mode(self):
         """Test that Completions uses default model when not specified in local mode."""
-        with patch.dict(os.environ, {"LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI'):
                 completions = Completions()
 
@@ -58,7 +58,7 @@ class TestCompletionsInit(SimpleTestCase):
 
     def test_completions_init_with_url_local_mode(self):
         """Test that Completions constructs correct URL in local mode (LLM_PORT set)."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client:
                 Completions()
 
@@ -100,7 +100,7 @@ class TestCompletionsInit(SimpleTestCase):
 
     def test_completions_init_creates_async_client_local_mode(self):
         """Test that Completions creates an AsyncOpenAI client in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 completions = Completions()
 
@@ -126,7 +126,7 @@ class TestCompletionsMethod(SimpleTestCase):
 
     async def test_completions_success_local_mode(self):
         """Test that completions method successfully generates a response in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
@@ -172,7 +172,7 @@ class TestCompletionsMethod(SimpleTestCase):
 
     async def test_completions_message_formatting_local_mode(self):
         """Test that completions correctly formats messages in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
@@ -234,7 +234,7 @@ class TestCompletionsMethod(SimpleTestCase):
 
     async def test_completions_uses_correct_model_local_mode(self):
         """Test that completions uses the correct model in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
@@ -286,7 +286,7 @@ class TestCompletionsMethod(SimpleTestCase):
         """Test that completions handles blank extra_body (empty dict) correctly in local mode."""
         with patch.dict(os.environ, {
             "LLM_MODEL_ID": "test-model",
-            "LLM_PORT": "11436",
+            "BASE_LLM_URL": "http://llm:11436/v1",
             "LLM_MODEL_ARGUMENTS": "{}"
         }, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
@@ -346,7 +346,7 @@ class TestCompletionsMethod(SimpleTestCase):
         model_args = {"chat_template_kwargs": {"temperature": 0.7, "max_tokens": 512}}
         with patch.dict(os.environ, {
             "LLM_MODEL_ID": "test-model",
-            "LLM_PORT": "11436",
+            "BASE_LLM_URL": "http://llm:11436/v1",
             "LLM_MODEL_ARGUMENTS": json.dumps(model_args)
         }, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
@@ -409,7 +409,7 @@ class TestCompletionsClose(SimpleTestCase):
 
     async def test_close_success_local_mode(self):
         """Test that close successfully closes the client in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client.close = AsyncMock()
@@ -439,7 +439,7 @@ class TestCompletionsClose(SimpleTestCase):
 
     async def test_close_handles_error_local_mode(self):
         """Test that close handles errors gracefully in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client.close = AsyncMock(side_effect=Exception("Close failed"))
@@ -473,7 +473,7 @@ class TestCompletionsClose(SimpleTestCase):
 
     async def test_close_logging_local_mode(self):
         """Test that close logs when closing in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client.close = AsyncMock()
@@ -512,7 +512,7 @@ class TestCompletionsIntegration(SimpleTestCase):
 
     async def test_completions_lifecycle_local_mode(self):
         """Test the full lifecycle of Completions object in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
@@ -572,7 +572,7 @@ class TestCompletionsIntegration(SimpleTestCase):
 
     async def test_multiple_completions_calls_local_mode(self):
         """Test multiple consecutive completions calls in local mode."""
-        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "LLM_PORT": "11436"}, clear=True):
+        with patch.dict(os.environ, {"LLM_MODEL_ID": "test-model", "BASE_LLM_URL": "http://llm:11436/v1"}, clear=True):
             with patch('ai.llm.completions.AsyncOpenAI') as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client

--- a/ai/tests/vdb/test_embedding.py
+++ b/ai/tests/vdb/test_embedding.py
@@ -11,7 +11,7 @@ def create_mock_getenv(**env_vars):
     Pass EMBEDDING_PORT="" and BASE_EMBEDDING_URL="..." to simulate API mode.
     """
     defaults = {
-        "EMBEDDING_PORT": "11435",
+        "BASE_EMBEDDING_URL": "http://embedding:11435/v1",
     }
     merged = {**defaults, **env_vars}
 
@@ -169,28 +169,23 @@ class TestEmbeddingInit(SimpleTestCase):
                     )
                     assert embedding.async_client is not None
 
-    def test_embedding_init_without_model_raises_error(self):
-        """Test that Embedding raises error when model ID is not set."""
+    def test_embedding_init_empty_model_falls_back_to_default(self):
+        """Test that empty EMBEDDING_MODEL_ID falls back to the Qwen default model."""
         env_vars = {
             "EMBEDDING_MODEL_ID": "",
-            "EMBEDDING_PORT": "11435",
         }
         with patch("ai.vdb.embedding.os.getenv") as mock_getenv:
             mock_getenv.side_effect = create_mock_getenv(**env_vars)
-            with patch("ai.vdb.embedding.logger") as mock_logger:
-                with patch("ai.vdb.embedding.OpenAI"):
-                    with patch("ai.vdb.embedding.AsyncOpenAI"):
-                        with pytest.raises(ValueError, match="Embedding model ID is not set"):
-                            Embedding()
-                        mock_logger.error.assert_called_once_with(
-                            "Embedding model ID is not set"
-                        )
+            with patch("ai.vdb.embedding.OpenAI"):
+                with patch("ai.vdb.embedding.AsyncOpenAI"):
+                    embedding = Embedding()
+                    assert embedding.model_name == "Qwen/Qwen3-Embedding-0.6B"
 
     def test_embedding_init_without_url_raises_error(self):
-        """Test that Embedding raises error when neither EMBEDDING_PORT nor BASE_EMBEDDING_URL is set."""
+        """Test that Embedding raises error when BASE_EMBEDDING_URL is not set."""
         env_vars = {
             "EMBEDDING_MODEL_ID": "test-model",
-            "EMBEDDING_PORT": "",
+            "BASE_EMBEDDING_URL": "",
         }
         with patch("ai.vdb.embedding.os.getenv") as mock_getenv:
             mock_getenv.side_effect = create_mock_getenv(**env_vars)

--- a/ai/tests/vdb/test_milvus_db.py
+++ b/ai/tests/vdb/test_milvus_db.py
@@ -18,7 +18,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_with_default_values(self):
         """Test VectorDatabaseBuilder initialization with default environment variables."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -31,7 +31,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
             with patch("ai.vdb.milvus_db.Embedding"):
                 with patch("ai.vdb.milvus_db.MilvusClient"):
                     builder = VectorDatabaseBuilder()
-                    assert builder.milvus_url == "http://localhost:19530"
+                    assert builder.milvus_url == "http://milvus:19530"
                     assert builder.milvus_database_name == "faith_db"
                     assert builder.milvus_username == "admin"
                     assert builder.milvus_password == "admin"
@@ -40,7 +40,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_database_type_sparse(self):
         """Test initialization with sparse database type."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -58,7 +58,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_database_type_dense(self):
         """Test initialization with dense database type."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -96,7 +96,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_invalid_database_type(self):
         """Test that invalid database type raises ValueError."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -115,7 +115,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_creates_milvus_client(self):
         """Test that MilvusClient is created with correct parameters."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -129,14 +129,14 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
                 with patch("ai.vdb.milvus_db.MilvusClient") as mock_client_class:
                     VectorDatabaseBuilder()
                     mock_client_class.assert_called_once_with(
-                        uri="http://localhost:19530",
+                        uri="http://milvus:19530",
                         token="admin:admin"
                     )
 
     def test_init_creates_embedding_engine(self):
         """Test that Embedding engine is created during initialization."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -152,13 +152,31 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
                     mock_embedding_class.assert_called_once()
                     assert builder.embedding_engine is not None
 
+    def test_init_invalid_password(self):
+        """Test that invalid password raises ValueError."""
+        env_vars = {
+            "MILVUS_HOST": "http://milvus",
+            "MILVUS_PORT": "19530",
+            "MILVUS_DATABASE_NAME": "faith_db",
+            "MILVUS_USERNAME": "admin",
+            "MILVUS_PASSWORD": "CHANGE_ME_use_a_strong_password",
+            "DATABASE_TYPE": "hybrid",
+            "EMBEDDING_MODEL_ID": "test-model",
+        }
+        with patch("ai.vdb.milvus_db.os.getenv") as mock_getenv:
+            mock_getenv.side_effect = create_mock_getenv(**env_vars)
+            with patch("ai.vdb.milvus_db.Embedding"):
+                with patch("ai.vdb.milvus_db.MilvusClient"):
+                    with pytest.raises(ValueError, match="MILVUS_PASSWORD environment variable is not set or was set to the default value"):
+                        VectorDatabaseBuilder()
+
 class TestLoadDatabase(SimpleTestCase):
     """Tests for load_database method."""
 
     def test_load_database_success(self):
         """Test successful database loading."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -181,7 +199,7 @@ class TestLoadDatabase(SimpleTestCase):
     def test_load_database_error(self):
         """Test error handling during database loading."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -208,7 +226,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_load_existing_database(self):
         """Test loading an existing database."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -235,7 +253,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_new_database(self):
         """Test creating a new database when no databases exist at all."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -263,7 +281,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_new_database_with_existing_databases(self):
         """Test creating a new database when it does not exist in existing databases."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -291,7 +309,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_database_error(self):
         """Test error handling during database creation."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -320,7 +338,7 @@ class TestListCollectionsInDatabase(SimpleTestCase):
     def test_list_collections_success(self):
         """Test successfully listing collections."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -346,7 +364,7 @@ class TestListCollectionsInDatabase(SimpleTestCase):
     def test_list_collections_error(self):
         """Test error handling when listing collections fails."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -374,7 +392,7 @@ class TestDropCollection(SimpleTestCase):
     def test_drop_collection_success(self):
         """Test successfully dropping a collection."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -416,7 +434,7 @@ class TestDropCollection(SimpleTestCase):
     def test_drop_collection_warning(self):
         """Test that warning is logged when dropping non-existent collection."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -448,7 +466,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_all_collections_default(self):
         """Test creating all collections when no specific names are provided."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -482,7 +500,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_specific_collection_valid(self):
         """Test creating specific collections with valid names."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -516,7 +534,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_collection_invalid_name(self):
         """Test error when creating collection with invalid name."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -545,7 +563,7 @@ class TestClose(SimpleTestCase):
     def test_close_success(self):
         """Test successfully closing the database connection."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -568,7 +586,7 @@ class TestClose(SimpleTestCase):
     def test_close_error(self):
         """Test error handling during database closing."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -596,7 +614,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
     def test_querier_init_with_default_values(self):
         """Test VectorDatabaseQuerier initialization with default values."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -608,7 +626,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
             mock_getenv.side_effect = create_mock_getenv(**env_vars)
             with patch("ai.vdb.milvus_db.Embedding"):
                 querier = VectorDatabaseQuerier()
-                assert querier.milvus_url == "http://localhost:19530"
+                assert querier.milvus_url == "http://milvus:19530"
                 assert querier.milvus_database_name == "faith_db"
                 assert querier.database_type == "hybrid"
                 assert querier.async_client is None
@@ -616,7 +634,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
     def test_querier_invalid_database_type(self):
         """Test that invalid database type raises ValueError in querier."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -639,7 +657,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_and_collections_success(self):
         """Test successfully loading database and collections."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -670,7 +688,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_not_found(self):
         """Test error when database doesn't exist."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "nonexistent_db",
             "MILVUS_USERNAME": "admin",
@@ -699,7 +717,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_not_found_in_existing_databases(self):
         """Test error when database doesn't exist."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "nonexistent_db",
             "MILVUS_USERNAME": "admin",
@@ -732,7 +750,7 @@ class TestVectorDatabaseQuerierListCollections(SimpleTestCase):
     async def test_list_collections_success(self):
         """Test successfully listing collections asynchronously."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -759,7 +777,7 @@ class TestVectorDatabaseQuerierListCollections(SimpleTestCase):
     async def test_list_collections_error(self):
         """Test error handling when listing collections fails."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -788,7 +806,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_hybrid_mode(self):
         """Test search in hybrid mode."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -820,7 +838,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_dense_mode(self):
         """Test search in dense mode."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -850,7 +868,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_sparse_mode(self):
         """Test search in sparse mode."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -883,7 +901,7 @@ class TestVectorDatabaseQuerierClose(SimpleTestCase):
     async def test_close_with_active_client(self):
         """Test closing when async client is active."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -908,7 +926,7 @@ class TestVectorDatabaseQuerierClose(SimpleTestCase):
     async def test_close_with_no_client(self):
         """Test closing when no async client exists."""
         env_vars = {
-            "MILVUS_HOST": "http://localhost",
+            "MILVUS_HOST": "http://milvus",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",

--- a/ai/tests/vdb/test_milvus_db.py
+++ b/ai/tests/vdb/test_milvus_db.py
@@ -18,7 +18,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_with_default_values(self):
         """Test VectorDatabaseBuilder initialization with default environment variables."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -31,8 +31,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
             with patch("ai.vdb.milvus_db.Embedding"):
                 with patch("ai.vdb.milvus_db.MilvusClient"):
                     builder = VectorDatabaseBuilder()
-                    assert builder.milvus_url == "http://localhost"
-                    assert builder.milvus_port == "19530"
+                    assert builder.milvus_url == "http://localhost:19530"
                     assert builder.milvus_database_name == "faith_db"
                     assert builder.milvus_username == "admin"
                     assert builder.milvus_password == "admin"
@@ -41,7 +40,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_database_type_sparse(self):
         """Test initialization with sparse database type."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -59,7 +58,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_database_type_dense(self):
         """Test initialization with dense database type."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -77,7 +76,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_with_custom_values(self):
         """Test VectorDatabaseBuilder initialization with custom environment variables."""
         env_vars = {
-            "MILVUS_URL": "http://milvus.example.com",
+            "MILVUS_HOST": "http://milvus.example.com",
             "MILVUS_PORT": "19531",
             "MILVUS_DATABASE_NAME": "custom_db",
             "MILVUS_USERNAME": "user",
@@ -90,15 +89,14 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
             with patch("ai.vdb.milvus_db.Embedding"):
                 with patch("ai.vdb.milvus_db.MilvusClient"):
                     builder = VectorDatabaseBuilder()
-                    assert builder.milvus_url == "http://milvus.example.com"
-                    assert builder.milvus_port == "19531"
+                    assert builder.milvus_url == "http://milvus.example.com:19531"
                     assert builder.milvus_database_name == "custom_db"
                     assert builder.database_type == "dense"
 
     def test_init_invalid_database_type(self):
         """Test that invalid database type raises ValueError."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -117,7 +115,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_creates_milvus_client(self):
         """Test that MilvusClient is created with correct parameters."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -138,7 +136,7 @@ class TestVectorDatabaseBuilderInit(SimpleTestCase):
     def test_init_creates_embedding_engine(self):
         """Test that Embedding engine is created during initialization."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -160,7 +158,7 @@ class TestLoadDatabase(SimpleTestCase):
     def test_load_database_success(self):
         """Test successful database loading."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -183,7 +181,7 @@ class TestLoadDatabase(SimpleTestCase):
     def test_load_database_error(self):
         """Test error handling during database loading."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -210,7 +208,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_load_existing_database(self):
         """Test loading an existing database."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -237,7 +235,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_new_database(self):
         """Test creating a new database when no databases exist at all."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -265,7 +263,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_new_database_with_existing_databases(self):
         """Test creating a new database when it does not exist in existing databases."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -293,7 +291,7 @@ class TestLoadOrCreateDatabase(SimpleTestCase):
     def test_create_database_error(self):
         """Test error handling during database creation."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -322,7 +320,7 @@ class TestListCollectionsInDatabase(SimpleTestCase):
     def test_list_collections_success(self):
         """Test successfully listing collections."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -348,7 +346,7 @@ class TestListCollectionsInDatabase(SimpleTestCase):
     def test_list_collections_error(self):
         """Test error handling when listing collections fails."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -376,7 +374,7 @@ class TestDropCollection(SimpleTestCase):
     def test_drop_collection_success(self):
         """Test successfully dropping a collection."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -418,7 +416,7 @@ class TestDropCollection(SimpleTestCase):
     def test_drop_collection_warning(self):
         """Test that warning is logged when dropping non-existent collection."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -450,7 +448,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_all_collections_default(self):
         """Test creating all collections when no specific names are provided."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -484,7 +482,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_specific_collection_valid(self):
         """Test creating specific collections with valid names."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -518,7 +516,7 @@ class TestCreateCollections(SimpleTestCase):
     def test_create_collection_invalid_name(self):
         """Test error when creating collection with invalid name."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -547,7 +545,7 @@ class TestClose(SimpleTestCase):
     def test_close_success(self):
         """Test successfully closing the database connection."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -570,7 +568,7 @@ class TestClose(SimpleTestCase):
     def test_close_error(self):
         """Test error handling during database closing."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -598,7 +596,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
     def test_querier_init_with_default_values(self):
         """Test VectorDatabaseQuerier initialization with default values."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -610,8 +608,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
             mock_getenv.side_effect = create_mock_getenv(**env_vars)
             with patch("ai.vdb.milvus_db.Embedding"):
                 querier = VectorDatabaseQuerier()
-                assert querier.milvus_url == "http://localhost"
-                assert querier.milvus_port == "19530"
+                assert querier.milvus_url == "http://localhost:19530"
                 assert querier.milvus_database_name == "faith_db"
                 assert querier.database_type == "hybrid"
                 assert querier.async_client is None
@@ -619,7 +616,7 @@ class TestVectorDatabaseQuerierInit(SimpleTestCase):
     def test_querier_invalid_database_type(self):
         """Test that invalid database type raises ValueError in querier."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -642,7 +639,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_and_collections_success(self):
         """Test successfully loading database and collections."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -673,7 +670,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_not_found(self):
         """Test error when database doesn't exist."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "nonexistent_db",
             "MILVUS_USERNAME": "admin",
@@ -702,7 +699,7 @@ class TestVectorDatabaseQuerierLoadDatabaseAndCollections(SimpleTestCase):
     async def test_load_database_not_found_in_existing_databases(self):
         """Test error when database doesn't exist."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "nonexistent_db",
             "MILVUS_USERNAME": "admin",
@@ -735,7 +732,7 @@ class TestVectorDatabaseQuerierListCollections(SimpleTestCase):
     async def test_list_collections_success(self):
         """Test successfully listing collections asynchronously."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -762,7 +759,7 @@ class TestVectorDatabaseQuerierListCollections(SimpleTestCase):
     async def test_list_collections_error(self):
         """Test error handling when listing collections fails."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -791,7 +788,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_hybrid_mode(self):
         """Test search in hybrid mode."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -823,7 +820,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_dense_mode(self):
         """Test search in dense mode."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -853,7 +850,7 @@ class TestVectorDatabaseQuerierSearch(SimpleTestCase):
     async def test_search_sparse_mode(self):
         """Test search in sparse mode."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -886,7 +883,7 @@ class TestVectorDatabaseQuerierClose(SimpleTestCase):
     async def test_close_with_active_client(self):
         """Test closing when async client is active."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",
@@ -911,7 +908,7 @@ class TestVectorDatabaseQuerierClose(SimpleTestCase):
     async def test_close_with_no_client(self):
         """Test closing when no async client exists."""
         env_vars = {
-            "MILVUS_URL": "http://localhost",
+            "MILVUS_HOST": "http://localhost",
             "MILVUS_PORT": "19530",
             "MILVUS_DATABASE_NAME": "faith_db",
             "MILVUS_USERNAME": "admin",

--- a/ai/vdb/embedding.py
+++ b/ai/vdb/embedding.py
@@ -2,14 +2,11 @@ import logging
 import os
 
 import numpy as np
-from dotenv import load_dotenv
 from openai import OpenAI, AsyncOpenAI
 
 # Set up logging
 logger = logging.getLogger(__name__)
 
-# Load environment variables
-load_dotenv()
 
 
 class Embedding:
@@ -24,7 +21,7 @@ class Embedding:
 
     Configuration from environment variables:
         - EMBEDDING_MODEL_ID: Model identifier (default: "Qwen/Qwen3-Embedding-0.6B")
-        - BASE_EMBEDDING_URL: Service endpoint (default: http://localhost:11435/v1)
+        - BASE_EMBEDDING_URL: Service endpoint (default: http://embedding:11435/v1)
         - EMBEDDING_API_KEY: Authentication key
         - EMBEDDING_MODEL_QUERY_PROMPT: Template for query embeddings (optional)
         - EMBEDDING_MODEL_DOCUMENT_PROMPT: Template for document embeddings (optional)
@@ -47,15 +44,11 @@ class Embedding:
             raise ValueError("Embedding model ID is not set")
         logger.info(f"Embedding model ID: {self.model_name}")
 
-        # Build service endpoint URL
-        embedding_port = str(os.getenv("EMBEDDING_PORT", "")).strip()
-        if embedding_port:
-            base_url = f"http://embedding:{embedding_port}/v1"
-        else:
-            base_url = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
-            if not base_url:
-                logger.error("Base embedding URL is not set")
-                raise ValueError("Base embedding URL is not set")
+        # Use pre-computed embedding URL from docker-compose or environment
+        base_url = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
+        if not base_url:
+            logger.error("Base embedding URL is not set")
+            raise ValueError("Base embedding URL is not set")
         logger.info(f"Base embedding URL: {base_url}")
 
         api_key = str(os.getenv("EMBEDDING_API_KEY", "")).strip()

--- a/ai/vdb/embedding.py
+++ b/ai/vdb/embedding.py
@@ -38,31 +38,35 @@ class Embedding:
             ValueError: If EMBEDDING_MODEL_ID is not set.
         """
         # Load and validate embedding model configuration
-        self.model_name = str(os.getenv("EMBEDDING_MODEL_ID", "Qwen/Qwen3-Embedding-0.6B")).strip()
+        self.model_name = str(os.getenv("EMBEDDING_MODEL_ID") or "Qwen/Qwen3-Embedding-0.6B").strip()
         if not self.model_name:
             logger.error("Embedding model ID is not set")
             raise ValueError("Embedding model ID is not set")
         logger.info(f"Embedding model ID: {self.model_name}")
 
         # Use pre-computed embedding URL from docker-compose or environment
-        base_url = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
+        base_url = str(os.getenv("BASE_EMBEDDING_URL") or "").strip()
         if not base_url:
             logger.error("Base embedding URL is not set")
             raise ValueError("Base embedding URL is not set")
         logger.info(f"Base embedding URL: {base_url}")
 
-        api_key = str(os.getenv("EMBEDDING_API_KEY", "")).strip()
+        # Validate embedding API key
+        api_key = str(os.getenv("EMBEDDING_API_KEY") or "").strip()
         if not api_key:
             logger.warning("Embedding API key is not set")
-        logger.info(f"Embedding API key: {api_key}")
 
         # Initialize both sync and async clients for OpenAI-compatible API
         self.client = OpenAI(base_url=base_url, api_key=api_key)
         self.async_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
 
         # Load optional prompt templates for specialized embeddings
-        self.query_template = str(os.getenv("EMBEDDING_MODEL_QUERY_PROMPT", "")).strip()
-        self.document_template = str(os.getenv("EMBEDDING_MODEL_DOCUMENT_PROMPT", "")).strip()
+        self.query_template = str(os.getenv("EMBEDDING_MODEL_QUERY_PROMPT") or "").strip()
+        if not self.query_template:
+            logger.warning("Embedding query template is not set")
+        self.document_template = str(os.getenv("EMBEDDING_MODEL_DOCUMENT_PROMPT") or "").strip()
+        if not self.document_template:
+            logger.warning("Embedding document template is not set")
 
     def embedding_size(self):
         """

--- a/ai/vdb/milvus_db.py
+++ b/ai/vdb/milvus_db.py
@@ -20,7 +20,7 @@ class VectorDatabaseBuilder:
     It supports three embedding strategies: sparse (BM25), dense (HNSW), or hybrid (both).
 
     Configuration is read from environment variables:
-        - MILVUS_URL, MILVUS_PORT: Connection details
+        - MILVUS_HOST, MILVUS_PORT: Connection details
         - MILVUS_DATABASE_NAME: Database name
         - MILVUS_USERNAME, MILVUS_PASSWORD: Authentication credentials
         - DATABASE_TYPE: "sparse", "dense", or "hybrid"
@@ -38,28 +38,34 @@ class VectorDatabaseBuilder:
         """
         # Load Milvus connection configuration
         # Use pre-computed Milvus URL from docker-compose or environment
-        milvus_host = str(os.getenv("MILVUS_HOST", "")).strip()
-        milvus_port = str(os.getenv("MILVUS_PORT", "19530")).strip()
+        milvus_host = str(os.getenv("MILVUS_HOST") or "http://milvus").strip()
+        milvus_port = str(os.getenv("MILVUS_PORT") or "19530").strip()
 
         # Validate Milvus host and port
         if not milvus_host or not milvus_port:
             logger.error("Milvus host or port is not set")
             raise ValueError("Milvus host or port is not set")
 
+        # If Milvus host is not a valid URL, add http:// prefix to make it a valid URL
+        if not milvus_host.startswith(("http://", "https://")):
+            milvus_host = f"http://{milvus_host}"
+
         self.milvus_url = f"{milvus_host}:{milvus_port}"
-        self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME", "faith_db")).strip()
-        self.milvus_username = str(os.getenv("MILVUS_USERNAME", "admin")).strip()
-        self.milvus_password = str(os.getenv("MILVUS_PASSWORD", "admin")).strip()
+        self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME") or "fAIth").strip()
+        self.milvus_username = str(os.getenv("MILVUS_USERNAME") or "root").strip()
+        self.milvus_password = os.getenv("MILVUS_PASSWORD")
+        if not self.milvus_password:
+            raise ValueError("MILVUS_PASSWORD environment variable is not set")
 
         # Initialize embedding engine for generating vector embeddings
         self.embedding_engine = Embedding()
         
         # Validate and load database type (determines schema and indexing strategy)
-        self.database_type = str(os.getenv("DATABASE_TYPE", "hybrid")).strip().lower()
+        self.database_type = str(os.getenv("DATABASE_TYPE") or "hybrid").strip().lower()
         if self.database_type not in ["sparse", "dense", "hybrid"]:
             logger.error(f"Invalid database type: {self.database_type}")
             raise ValueError(f"Invalid database type: {self.database_type}. Valid database types are: sparse, dense, hybrid")
-        
+
         # Establish synchronous connection to Milvus
         self.client = MilvusClient(uri=self.milvus_url, token=f"{self.milvus_username}:{self.milvus_password}")
 
@@ -136,7 +142,7 @@ class VectorDatabaseBuilder:
         except Exception as e:
             logger.warning(f"Error dropping collection or collection does not exist: {e}")
 
-    def create_collections(self, collection_names: list[str] = []):
+    def create_collections(self, collection_names: list[str] | None = None):
         """
         Create collections with appropriate schema and build indices for all Bible verses.
 
@@ -339,7 +345,7 @@ class VectorDatabaseQuerier:
     Designed to be used with Django's lifespan manager for app-wide resource management.
 
     Configuration is read from environment variables:
-        - MILVUS_URL, MILVUS_PORT: Connection details
+        - MILVUS_HOST, MILVUS_PORT: Connection details
         - MILVUS_DATABASE_NAME: Database name
         - MILVUS_USERNAME, MILVUS_PASSWORD: Authentication credentials
         - DATABASE_TYPE: "sparse", "dense", or "hybrid"
@@ -357,22 +363,26 @@ class VectorDatabaseQuerier:
             ValueError: If DATABASE_TYPE is not one of: sparse, dense, hybrid
         """
         # Load Milvus connection configuration
-        # Use pre-computed Milvus URL from docker-compose or environment
-        milvus_url = str(os.getenv("MILVUS_URL", "")).strip()
-        if not milvus_url:
-            logger.error("Milvus URL is not set")
-            raise ValueError("Milvus URL is not set")
-        
-        self.milvus_url = milvus_url
-        self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME", "faith_db")).strip()
-        self.milvus_username = str(os.getenv("MILVUS_USERNAME", "admin")).strip()
-        self.milvus_password = str(os.getenv("MILVUS_PASSWORD", "admin")).strip()
+        milvus_host = str(os.getenv("MILVUS_HOST") or "http://milvus").strip()
+        milvus_port = str(os.getenv("MILVUS_PORT") or "19530").strip()
+
+        if not milvus_host.startswith(("http://", "https://")):
+            milvus_host = f"http://{milvus_host}"
+
+        self.milvus_url = f"{milvus_host}:{milvus_port}"
+        self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME") or "fAIth").strip()
+        self.milvus_username = str(os.getenv("MILVUS_USERNAME") or "root").strip()
+        self.milvus_password = os.getenv("MILVUS_PASSWORD")
+        if not self.milvus_password:
+            raise ValueError("MILVUS_PASSWORD environment variable is not set")
+        self.sparse_weight = float(str(os.getenv("SPARSE_WEIGHT") or 0.2).strip())
+        self.dense_weight = float(str(os.getenv("DENSE_WEIGHT") or 0.8).strip())
 
         # Initialize embedding engine for query embeddings
         self.embedding_engine = Embedding()
 
         # Validate and load database type (determines search strategy)
-        self.database_type = str(os.getenv("DATABASE_TYPE", "hybrid")).strip().lower()
+        self.database_type = str(os.getenv("DATABASE_TYPE") or "hybrid").strip().lower()
         if self.database_type not in ["sparse", "dense", "hybrid"]:
             logger.error(f"Invalid database type: {self.database_type}")
             raise ValueError(f"Invalid database type: {self.database_type}. Valid database types are: sparse, dense, hybrid")
@@ -398,7 +408,7 @@ class VectorDatabaseQuerier:
 
         # Create temporary client to check database existence
         temp_client = AsyncMilvusClient(
-            uri=f"{self.milvus_url}{':' if self.milvus_port else ''}{self.milvus_port}",
+            uri=self.milvus_url,
             token=f"{self.milvus_username}:{self.milvus_password}",
         )
         # List available databases
@@ -412,7 +422,7 @@ class VectorDatabaseQuerier:
             # Create async client with correct database context
             logger.info(f"Using database {self.milvus_database_name}")
             self.async_client = AsyncMilvusClient(
-                uri=f"{self.milvus_url}{':' if self.milvus_port else ''}{self.milvus_port}",
+                uri=self.milvus_url,
                 token=f"{self.milvus_username}:{self.milvus_password}",
                 db_name=self.milvus_database_name,
             )
@@ -510,15 +520,11 @@ class VectorDatabaseQuerier:
 
         # Perform hybrid search (combining sparse and dense with weighted rank fusion)
         if self.database_type == "hybrid":
-            # Load weights for combining sparse and dense results
-            sparse_weight = float(str(os.getenv("SPARSE_WEIGHT", 0.2)).strip())
-            dense_weight = float(str(os.getenv("DENSE_WEIGHT", 0.8)).strip())
-
             # Hybrid search combines BM25 and semantic similarity via reciprocal rank fusion
             hybrid_results = await self.async_client.hybrid_search(
                 collection_name=collection_name,
                 reqs=request_types,
-                ranker=WeightedRanker(sparse_weight, dense_weight),
+                ranker=WeightedRanker(self.sparse_weight, self.dense_weight),
                 limit=limit,
                 output_fields=["version", "book", "chapter", "verse", "text"]
             )

--- a/ai/vdb/milvus_db.py
+++ b/ai/vdb/milvus_db.py
@@ -54,8 +54,8 @@ class VectorDatabaseBuilder:
         self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME") or "fAIth").strip()
         self.milvus_username = str(os.getenv("MILVUS_USERNAME") or "root").strip()
         self.milvus_password = os.getenv("MILVUS_PASSWORD")
-        if not self.milvus_password:
-            raise ValueError("MILVUS_PASSWORD environment variable is not set")
+        if not self.milvus_password or self.milvus_password == "CHANGE_ME_use_a_strong_password":
+            raise ValueError("MILVUS_PASSWORD environment variable is not set or was set to the default value")
 
         # Initialize embedding engine for generating vector embeddings
         self.embedding_engine = Embedding()
@@ -373,8 +373,8 @@ class VectorDatabaseQuerier:
         self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME") or "fAIth").strip()
         self.milvus_username = str(os.getenv("MILVUS_USERNAME") or "root").strip()
         self.milvus_password = os.getenv("MILVUS_PASSWORD")
-        if not self.milvus_password:
-            raise ValueError("MILVUS_PASSWORD environment variable is not set")
+        if not self.milvus_password or self.milvus_password == "CHANGE_ME_use_a_strong_password":
+            raise ValueError("MILVUS_PASSWORD environment variable is not set or was set to the default value")
         self.sparse_weight = float(str(os.getenv("SPARSE_WEIGHT") or 0.2).strip())
         self.dense_weight = float(str(os.getenv("DENSE_WEIGHT") or 0.8).strip())
 

--- a/ai/vdb/milvus_db.py
+++ b/ai/vdb/milvus_db.py
@@ -38,12 +38,15 @@ class VectorDatabaseBuilder:
         """
         # Load Milvus connection configuration
         # Use pre-computed Milvus URL from docker-compose or environment
-        milvus_url = str(os.getenv("MILVUS_URL", "")).strip()
-        if not milvus_url:
-            logger.error("Milvus URL is not set")
-            raise ValueError("Milvus URL is not set")
-        
-        self.milvus_url = milvus_url
+        milvus_host = str(os.getenv("MILVUS_HOST", "")).strip()
+        milvus_port = str(os.getenv("MILVUS_PORT", "19530")).strip()
+
+        # Validate Milvus host and port
+        if not milvus_host or not milvus_port:
+            logger.error("Milvus host or port is not set")
+            raise ValueError("Milvus host or port is not set")
+
+        self.milvus_url = f"{milvus_host}:{milvus_port}"
         self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME", "faith_db")).strip()
         self.milvus_username = str(os.getenv("MILVUS_USERNAME", "admin")).strip()
         self.milvus_password = str(os.getenv("MILVUS_PASSWORD", "admin")).strip()

--- a/ai/vdb/milvus_db.py
+++ b/ai/vdb/milvus_db.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 
-from dotenv import load_dotenv
 from pymilvus import MilvusClient, AsyncMilvusClient, CollectionSchema, FieldSchema, DataType, Function, FunctionType, AnnSearchRequest, WeightedRanker
 
 from ai.vdb.embedding import Embedding
@@ -11,9 +10,6 @@ import fAIth.bible_globals as bible_globals
 
 # Set up logging
 logger = logging.getLogger(__name__)
-
-# Load environment variables
-load_dotenv()
 
 
 class VectorDatabaseBuilder:
@@ -41,8 +37,13 @@ class VectorDatabaseBuilder:
             ValueError: If DATABASE_TYPE is not one of: sparse, dense, hybrid
         """
         # Load Milvus connection configuration
-        self.milvus_url = str(os.getenv("MILVUS_URL", "http://localhost")).strip()
-        self.milvus_port = str(os.getenv("MILVUS_PORT", "19530")).strip()
+        # Use pre-computed Milvus URL from docker-compose or environment
+        milvus_url = str(os.getenv("MILVUS_URL", "")).strip()
+        if not milvus_url:
+            logger.error("Milvus URL is not set")
+            raise ValueError("Milvus URL is not set")
+        
+        self.milvus_url = milvus_url
         self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME", "faith_db")).strip()
         self.milvus_username = str(os.getenv("MILVUS_USERNAME", "admin")).strip()
         self.milvus_password = str(os.getenv("MILVUS_PASSWORD", "admin")).strip()
@@ -57,7 +58,7 @@ class VectorDatabaseBuilder:
             raise ValueError(f"Invalid database type: {self.database_type}. Valid database types are: sparse, dense, hybrid")
         
         # Establish synchronous connection to Milvus
-        self.client = MilvusClient(uri=f"{self.milvus_url}{':' if self.milvus_port else ''}{self.milvus_port}", token=f"{self.milvus_username}:{self.milvus_password}")
+        self.client = MilvusClient(uri=self.milvus_url, token=f"{self.milvus_username}:{self.milvus_password}")
 
     def load_database(self):
         """
@@ -353,8 +354,13 @@ class VectorDatabaseQuerier:
             ValueError: If DATABASE_TYPE is not one of: sparse, dense, hybrid
         """
         # Load Milvus connection configuration
-        self.milvus_url = str(os.getenv("MILVUS_URL", "http://localhost")).strip()
-        self.milvus_port = str(os.getenv("MILVUS_PORT", "19530")).strip()
+        # Use pre-computed Milvus URL from docker-compose or environment
+        milvus_url = str(os.getenv("MILVUS_URL", "")).strip()
+        if not milvus_url:
+            logger.error("Milvus URL is not set")
+            raise ValueError("Milvus URL is not set")
+        
+        self.milvus_url = milvus_url
         self.milvus_database_name = str(os.getenv("MILVUS_DATABASE_NAME", "faith_db")).strip()
         self.milvus_username = str(os.getenv("MILVUS_USERNAME", "admin")).strip()
         self.milvus_password = str(os.getenv("MILVUS_PASSWORD", "admin")).strip()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     image: chrislusf/seaweedfs:4.03
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/healthz"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -91,7 +91,7 @@ services:
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/healthz"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -170,7 +170,7 @@ services:
 
   embedding:
     container_name: llama-cpp-embedding-faith
-    image: ghcr.io/ggml-org/llama.cpp:server
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     environment:
@@ -184,10 +184,18 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: cdi
+              device_ids:
+                - nvidia.com/gpu=all
+              capabilities: [gpu]
 
   llm:
     container_name: llama-cpp-llm-faith
-    image: ghcr.io/ggml-org/llama.cpp:server
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     environment:
@@ -201,6 +209,14 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: cdi
+              device_ids:
+                - nvidia.com/gpu=all
+              capabilities: [gpu]
 
   webapp:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:latest
     environment:
       POSTGRES_USER: faith_user
-      POSTGRES_PASSWORD: postgres-secure-password
+      POSTGRES_PASSWORD: CHANGE_ME_use_a_strong_password
       POSTGRES_DB: faith_db
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/postgres:/var/lib/postgresql
@@ -91,7 +91,7 @@ services:
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -170,7 +170,7 @@ services:
 
   embedding:
     container_name: llama-cpp-embedding-faith
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ghcr.io/ggml-org/llama.cpp:server
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     environment:
@@ -184,18 +184,10 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: cdi
-              device_ids:
-                - nvidia.com/gpu=all
-              capabilities: [gpu]
 
   llm:
     container_name: llama-cpp-llm-faith
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ghcr.io/ggml-org/llama.cpp:server
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
     environment:
@@ -209,14 +201,6 @@ services:
       interval: 30s
       timeout: 30s
       retries: 5
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: cdi
-              device_ids:
-                - nvidia.com/gpu=all
-              capabilities: [gpu]
 
   webapp:
     build:
@@ -228,16 +212,6 @@ services:
     env_file:
       - .env
     environment:
-      DJANGO_DEBUG: False
-      DJANGO_SECRET_KEY: 'django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s('
-      DJANGO_ALLOWED_HOSTS: '["127.0.0.1", "localhost"]'
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_USER: faith_user
-      POSTGRES_PASSWORD: postgres-secure-password
-      POSTGRES_DATABASE: faith_db
-      MILVUS_HOST: milvus
-      MILVUS_PORT: 19530
       BASE_EMBEDDING_URL: http://embedding:11435/v1
       BASE_LLM_URL: http://llm:11436/v1
     command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers 1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/postgres:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "faith_user", "-d", "faith_db"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -30,6 +31,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
     healthcheck:
       test: ["CMD", "etcdctl", "endpoint", "health"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -42,6 +44,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/seaweedfs/master:/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-master:9333/cluster/status"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -54,6 +57,7 @@ services:
     command: 'volume -ip=seaweedfs-volume -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325 -dir=/data'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-volume:8080/status"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -67,6 +71,7 @@ services:
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -87,6 +92,7 @@ services:
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
       test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
+      start_period: 3600s
       interval: 30s
       timeout: 30s
       retries: 5
@@ -230,7 +236,8 @@ services:
       POSTGRES_USER: faith_user
       POSTGRES_PASSWORD: postgres-secure-password
       POSTGRES_DATABASE: faith_db
-      MILVUS_URL: http://milvus:19530
+      MILVUS_HOST: milvus
+      MILVUS_PORT: 19530
       BASE_EMBEDDING_URL: http://embedding:11435/v1
       BASE_LLM_URL: http://llm:11436/v1
     command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers 1"
@@ -243,12 +250,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    
       milvus:
         condition: service_healthy
       embedding:
         condition: service_healthy
       llm:
         condition: service_healthy
+
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   postgres:
     container_name: postgres-faith
     image: postgres:latest
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_USER: faith_user
       POSTGRES_PASSWORD: postgres-secure-password
@@ -39,15 +37,11 @@ services:
   seaweedfs-master:
     container_name: seaweedfs-master-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 9333:9333
-      - 19333:19333
-      - 9324:9324
     command: 'master -ip=seaweedfs-master -ip.bind=0.0.0.0 -metricsPort=9324 -mdir=/data'
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/seaweedfs/master:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9333/cluster/status"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-master:9333/cluster/status"]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -55,15 +49,11 @@ services:
   seaweedfs-volume:
     container_name: seaweedfs-volume-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8080:8080
-      - 18080:18080
-      - 9325:9325
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/seaweedfs/volume:/data
     command: 'volume -ip=seaweedfs-volume -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325 -dir=/data'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-volume:8080/status"]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -74,13 +64,9 @@ services:
   seaweedfs-filer:
     container_name: seaweedfs-filer-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8888:8888
-      - 18888:18888
-      - 9326:9326
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -95,15 +81,12 @@ services:
   seaweedfs-s3:
     container_name: seaweedfs-s3-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8333:8333
-      - 9327:9327
     environment:
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8333/"]
+      test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
       interval: 30s
       timeout: 30s
       retries: 5
@@ -150,8 +133,6 @@ services:
   milvus:
     container_name: milvus-faith
     image: milvusdb/milvus:latest
-    ports:
-      - "19530:19530"
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: seaweedfs-s3:8333
@@ -164,7 +145,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
     command: ["milvus", "run", "standalone"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      test: ["CMD", "curl", "-f", "http://milvus:9091/healthz"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -186,15 +167,13 @@ services:
     image: ghcr.io/ggml-org/llama.cpp:server-cuda
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
-    ports:
-      - "11435:11435"
     environment:
       HF_TOKEN: 
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
     command: ["-hf", "Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0", "-c", "4096", "-ngl", "9999", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0", "--host", "0.0.0.0", "--port", "11435", "--cont-batching", "-np", "1", "--embedding"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11435/health"]
+      test: ["CMD", "curl", "-f", "http://embedding:11435/health"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -213,15 +192,13 @@ services:
     image: ghcr.io/ggml-org/llama.cpp:server-cuda
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/llama_cpp_cache:/root/.cache/huggingface
-    ports:
-      - "11436:11436"
     environment:
       HF_TOKEN: 
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
     command: ["-hf", "unsloth/Qwen3.5-4B-GGUF:Q4_K_M", "-c", "4096", "-ngl", "9999", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0", "--host", "0.0.0.0", "--port", "11436", "--cont-batching", "-np", "1", ]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11436/health"]
+      test: ["CMD", "curl", "-f", "http://llm:11436/health"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -245,13 +222,20 @@ services:
     env_file:
       - .env
     environment:
+      DJANGO_DEBUG: False
+      DJANGO_SECRET_KEY: 'django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s('
+      DJANGO_ALLOWED_HOSTS: '["127.0.0.1", "localhost"]'
       POSTGRES_HOST: postgres
-      MILVUS_URL: http://milvus
-      BASE_EMBEDDING_URL: http://embedding
-      BASE_LLM_URL: http://llm
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: faith_user
+      POSTGRES_PASSWORD: postgres-secure-password
+      POSTGRES_DATABASE: faith_db
+      MILVUS_URL: http://milvus:19530
+      BASE_EMBEDDING_URL: http://embedding:11435/v1
+      BASE_LLM_URL: http://llm:11436/v1
     command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers 1"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/healthcheck/"]
+      test: ["CMD", "curl", "-f", "http://webapp:8000/healthcheck/"]
       start_period: 3600s
       interval: 30s
       timeout: 30s
@@ -259,6 +243,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    
       milvus:
         condition: service_healthy
       embedding:

--- a/fAIth/settings.py
+++ b/fAIth/settings.py
@@ -89,11 +89,11 @@ ASGI_APPLICATION = "fAIth.asgi.application"
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip(),
+        'HOST': str(os.getenv("POSTGRES_HOST", "postgres")).strip(),
+        'PORT': str(os.getenv("POSTGRES_PORT", "5432")).strip(),
         'USER': str(os.getenv("POSTGRES_USER", "faith_user")).strip(),
         'PASSWORD': str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip(),
-        'HOST': str(os.getenv("POSTGRES_HOST", "postgres")).strip(),
-        'PORT': str(os.getenv("POSTGRES_PORT", "5432")).strip()
+        'NAME': str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
     }
 }
 

--- a/fAIth/settings.py
+++ b/fAIth/settings.py
@@ -29,8 +29,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
-if not SECRET_KEY:
-    raise ValueError("DJANGO_SECRET_KEY environment variable is not set")
+if not SECRET_KEY or SECRET_KEY == "CHANGE_ME_use_a_long_secret_key":
+    raise ValueError("DJANGO_SECRET_KEY environment variable is not set or was set to the default value")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = str(os.getenv("DJANGO_DEBUG") or "").strip().lower() in ("1", "true", "yes")

--- a/fAIth/settings.py
+++ b/fAIth/settings.py
@@ -15,7 +15,6 @@ import logging
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(name)s: %(message)s')
@@ -23,9 +22,6 @@ logger = logging.getLogger(__name__)
 
 # Build paths inside the project like this: BASE_DIR.joinpath('subdir').
 BASE_DIR = Path(__file__).resolve().parent.parent
-
-# Load environment variables
-load_dotenv()
 
 
 # Quick-start development settings - unsuitable for production
@@ -96,7 +92,7 @@ DATABASES = {
         'NAME': str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip(),
         'USER': str(os.getenv("POSTGRES_USER", "faith_user")).strip(),
         'PASSWORD': str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip(),
-        'HOST': str(os.getenv("POSTGRES_HOST", "localhost")).strip(),
+        'HOST': str(os.getenv("POSTGRES_HOST", "postgres")).strip(),
         'PORT': str(os.getenv("POSTGRES_PORT", "5432")).strip()
     }
 }

--- a/fAIth/settings.py
+++ b/fAIth/settings.py
@@ -28,12 +28,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = str(os.getenv("DJANGO_SECRET_KEY", "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(")).strip()
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    raise ValueError("DJANGO_SECRET_KEY environment variable is not set")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DJANGO_DEBUG", False)
+DEBUG = str(os.getenv("DJANGO_DEBUG") or "").strip().lower() in ("1", "true", "yes")
 
-ALLOWED_HOSTS = json.loads(str(os.getenv("DJANGO_ALLOWED_HOSTS", "[\"127.0.0.1\", \"localhost\"]")).strip())
+ALLOWED_HOSTS = json.loads(str(os.getenv("DJANGO_ALLOWED_HOSTS") or '["127.0.0.1", "localhost"]').strip())
 
 
 # Application definition
@@ -86,14 +88,27 @@ ASGI_APPLICATION = "fAIth.asgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
+postgres_host = str(os.getenv("POSTGRES_HOST") or "postgres").strip()
+postgres_port = str(os.getenv("POSTGRES_PORT") or "5432").strip()
+postgres_user = str(os.getenv("POSTGRES_USER") or "faith_user").strip()
+postgres_password = os.getenv("POSTGRES_PASSWORD")
+postgres_database = str(os.getenv("POSTGRES_DATABASE") or "faith_db").strip()
+
+if not postgres_password:
+    raise ValueError("POSTGRES_PASSWORD environment variable is not set")
+
+# If Postgres host is a valid URL, remove the protocol prefix to make it a valid Django database host URI
+if postgres_host.startswith(("http://", "https://")):
+    postgres_host = postgres_host.replace("http://", "").replace("https://", "")
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': str(os.getenv("POSTGRES_HOST", "postgres")).strip(),
-        'PORT': str(os.getenv("POSTGRES_PORT", "5432")).strip(),
-        'USER': str(os.getenv("POSTGRES_USER", "faith_user")).strip(),
-        'PASSWORD': str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip(),
-        'NAME': str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
+        'HOST': postgres_host,
+        'PORT': postgres_port,
+        'USER': postgres_user,
+        'PASSWORD': postgres_password,
+        'NAME': postgres_database
     }
 }
 

--- a/fAIth/settings.py
+++ b/fAIth/settings.py
@@ -94,8 +94,8 @@ postgres_user = str(os.getenv("POSTGRES_USER") or "faith_user").strip()
 postgres_password = os.getenv("POSTGRES_PASSWORD")
 postgres_database = str(os.getenv("POSTGRES_DATABASE") or "faith_db").strip()
 
-if not postgres_password:
-    raise ValueError("POSTGRES_PASSWORD environment variable is not set")
+if not postgres_password or postgres_password == "CHANGE_ME_use_a_strong_password":
+    raise ValueError("POSTGRES_PASSWORD environment variable is not set or was set to the default value")
 
 # If Postgres host is a valid URL, remove the protocol prefix to make it a valid Django database host URI
 if postgres_host.startswith(("http://", "https://")):

--- a/fAIth/test_settings.py
+++ b/fAIth/test_settings.py
@@ -1,0 +1,14 @@
+"""
+Django settings for the test suite.
+
+Sets the env vars that settings.py requires before importing it, so pytest-django
+can load settings during collection without a real .env file present.
+These values are test-only stubs and must never be used in production.
+"""
+import os
+
+os.environ.setdefault("DJANGO_SECRET_KEY", "test-only-secret-key-not-for-production")
+os.environ.setdefault("POSTGRES_PASSWORD", "test-only-postgres-password-not-for-production")
+os.environ.setdefault("MILVUS_PASSWORD", "test-only-milvus-password-not-for-production")
+
+from fAIth.settings import *  # noqa: F401, F403, E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 9999
+target-version = ["py312"]
+extend-exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.venv
+  | _build
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 9999

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = fAIth.settings
+DJANGO_SETTINGS_MODULE = fAIth.test_settings
 python_files = tests.py test_*.py *_tests.py
 testpaths = frontend/tests backend/tests ai/tests fAIth/tests
 norecursedirs = .git .venv volumes __pycache__ *.egg-info .pytest_cache

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -464,7 +464,7 @@ SGLANG_SETUP = """
     command: ["python", "-m", "sglang.launch_server", "--model-path", "{model_id}", "--max-total-tokens", "{max_context_length}", "--disable-cuda-graph", "--host", "0.0.0.0", "--port", "{model_port}"]
     ipc: host
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{model_port}/health"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{model_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -255,7 +255,7 @@ SEAWEEDFS_SETUP = """
     image: chrislusf/seaweedfs:4.03
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/healthz"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -276,7 +276,7 @@ SEAWEEDFS_SETUP = """
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/healthz"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -12,36 +12,10 @@ if str(PROJECT_ROOT) not in sys.path:
 load_dotenv()
 
 # ============================================================================
-# Configuration Loading from Environment Variables
-# ============================================================================
-
-# Webapp specific things
-WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT", 8000)).strip())
-UVICORN_WORKERS = int(str(os.getenv("UVICORN_WORKERS", 1)).strip())
-
-# Postgres specific things
-POSTGRES_PORT = str(os.getenv("POSTGRES_PORT", "5432")).strip()
-POSTGRES_USER = str(os.getenv("POSTGRES_USER", "faith_user")).strip()
-POSTGRES_PASSWORD = str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip()
-POSTGRES_DATABASE = str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
-
-# Milvus specific things
-MILVUS_PORT = str(os.getenv("MILVUS_PORT", "19530")).strip()
-
-# Hugging Face specific things
-HF_TOKEN = str(os.getenv("HF_TOKEN", "")).strip()
-
-# Healthcheck specific things
-START_PERIOD = "3600s"
-INTERVAL = "30s"
-TIMEOUT = "30s"
-RETRIES = 5
-
-# ============================================================================
 # Compatibility Matrix - Shows valid driver/runner/device combinations
 # ============================================================================
 
-COMPATBILITY_LIST = \
+COMPATIBILITY_LIST = \
 """
 Drivers:
     - `cpu`
@@ -199,8 +173,6 @@ POSTGRES_SETUP = \
   postgres:
     container_name: postgres-faith
     image: postgres:latest
-    ports:
-      - "{postgres_port}:5432"
     environment:
       POSTGRES_USER: {postgres_user}
       POSTGRES_PASSWORD: {postgres_password}
@@ -243,15 +215,11 @@ SEAWEEDFS_SETUP = \
   seaweedfs-master:
     container_name: seaweedfs-master-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 9333:9333
-      - 19333:19333
-      - 9324:9324
     command: 'master -ip=seaweedfs-master -ip.bind=0.0.0.0 -metricsPort=9324 -mdir=/data'
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/seaweedfs/master:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9333/cluster/status"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-master:9333/cluster/status"]
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -259,15 +227,11 @@ SEAWEEDFS_SETUP = \
   seaweedfs-volume:
     container_name: seaweedfs-volume-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8080:8080
-      - 18080:18080
-      - 9325:9325
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/seaweedfs/volume:/data
     command: 'volume -ip=seaweedfs-volume -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325 -dir=/data'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-volume:8080/status"]
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -278,13 +242,9 @@ SEAWEEDFS_SETUP = \
   seaweedfs-filer:
     container_name: seaweedfs-filer-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8888:8888
-      - 18888:18888
-      - 9326:9326
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -299,15 +259,12 @@ SEAWEEDFS_SETUP = \
   seaweedfs-s3:
     container_name: seaweedfs-s3-faith
     image: chrislusf/seaweedfs:4.03
-    ports:
-      - 8333:8333
-      - 9327:9327
     environment:
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "http://localhost:8333/"]
+      test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -353,7 +310,7 @@ SEAWEEDFS_SETUP = \
 """.lstrip('\n')
 
 # Milvus: vector database for semantic search
-def build_milvus_setup(milvus_port, embedding_enabled, start_period, interval, timeout, retries):
+def build_milvus_setup(local_embedding_enabled, start_period, interval, timeout, retries):
     """
     Build Milvus configuration with optional embedding dependency.
     
@@ -361,7 +318,6 @@ def build_milvus_setup(milvus_port, embedding_enabled, start_period, interval, t
     initial collections with embeddings during setup.
     
     Parameters:
-        milvus_port: Port to expose Milvus on
         embedding_enabled: True if EMBEDDING_PORT is set
         start_period, interval, timeout, retries: Healthcheck parameters
     
@@ -378,7 +334,7 @@ def build_milvus_setup(milvus_port, embedding_enabled, start_period, interval, t
         condition: service_completed_successfully"""
     
     # Only depend on embedding if it's enabled (for initial collection building)
-    if embedding_enabled:
+    if local_embedding_enabled:
         depends_on += """
       embedding:
         condition: service_healthy"""
@@ -387,8 +343,6 @@ def build_milvus_setup(milvus_port, embedding_enabled, start_period, interval, t
   milvus:
     container_name: milvus-faith
     image: milvusdb/milvus:latest
-    ports:
-      - "{milvus_port}:{milvus_port}"
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: seaweedfs-s3:8333
@@ -401,7 +355,7 @@ def build_milvus_setup(milvus_port, embedding_enabled, start_period, interval, t
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/milvus:/var/lib/milvus
     command: ["milvus", "run", "standalone"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      test: ["CMD", "curl", "-f", "http://milvus:9091/healthz"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -421,8 +375,6 @@ OLLAMA_SETUP = \
   {model_type}:
     container_name: ollama-{model_type}-faith
     image: {ollama_image}
-    ports:
-      - "{llm_port}:{llm_port}"
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/ollama:/root/.ollama
     environment:
@@ -432,7 +384,7 @@ OLLAMA_SETUP = \
       {ollama_force_cpu}
     command: ["serve"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{llm_port}/api/tags"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/api/tags"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -447,15 +399,13 @@ LLAMA_CPP_SETUP = \
     image: {llama_cpp_image}
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/llama_cpp_cache:/root/.cache/huggingface
-    ports:
-      - "{llm_port}:{llm_port}"
     environment:
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
     command: ["-hf", "{model_id}", "-c", "{max_context_length}", "-ngl", "{llama_cpp_gpu_layers}", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0", "--host", "0.0.0.0", "--port", "{llm_port}", "--cont-batching", "-np", "{llama_cpp_concurrency}", {embedding}]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{llm_port}/health"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -470,8 +420,6 @@ VLLM_SETUP = \
     image: {vllm_image}
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/vllm_cache:/root/.cache/huggingface
-    ports:
-      - "{llm_port}:{llm_port}"
     environment:
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
@@ -479,7 +427,7 @@ VLLM_SETUP = \
     command: ["--model", "{model_id}", "--download-dir", "/root/.cache/huggingface", "--max-model-len", "{max_context_length}", "--dtype", "auto", "--enforce-eager", "{vllm_enforce_eager}", "--host", "0.0.0.0", "--port", "{llm_port}"]
     ipc: host
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{llm_port}/health"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -496,8 +444,6 @@ SGLANG_SETUP = \
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/sglang_cache:/root/.cache/huggingface
     network_mode: host # required by RDMA
     privileged: true # required by RDMA
-    ports:
-      - "{llm_port}:{llm_port}"
     environment:
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
@@ -517,7 +463,26 @@ SGLANG_SETUP = \
 # Webapp Service Configuration - Built conditionally based on enabled services
 # ============================================================================
 
-def build_webapp_setup(embedding_enabled, llm_enabled, webapp_port, uvicorn_workers, start_period, interval, timeout, retries):
+def build_webapp_setup(
+  milvus_enabled,
+  milvus_url,
+  embedding_enabled,
+  embedding_url,
+  llm_enabled,
+  llm_url,
+  webapp_port, 
+  uvicorn_workers, 
+  django_debug, 
+  django_secret_key, 
+  django_allowed_hosts, 
+  postgres_port, 
+  postgres_user, 
+  postgres_password, 
+  postgres_database, 
+  start_period, 
+  interval, 
+  timeout, 
+  retries):
     """
     Build webapp configuration with conditional service dependencies.
     
@@ -525,10 +490,17 @@ def build_webapp_setup(embedding_enabled, llm_enabled, webapp_port, uvicorn_work
     will use external services (e.g., OpenAI, OpenRouter) configured via .env.
     
     Parameters:
+        milvus_enabled (bool): True if MILVUS_PORT is set
+        milvus_url: Complete Milvus URL
         embedding_enabled (bool): True if EMBEDDING_PORT is set
         llm_enabled (bool): True if LLM_PORT is set
         webapp_port: Port to expose webapp on
         uvicorn_workers: Number of uvicorn workers
+        django_debug: Django debug mode
+        django_secret_key: Django secret key
+        django_allowed_hosts: Django allowed hosts
+        postgres_port: Postgres port
+        postgres_user: Postgres user
         start_period, interval, timeout, retries: Healthcheck parameters
     
     Returns:
@@ -538,6 +510,10 @@ def build_webapp_setup(embedding_enabled, llm_enabled, webapp_port, uvicorn_work
     depends_on = """    depends_on:
       postgres:
         condition: service_healthy
+    """
+    
+    if milvus_enabled:
+        depends_on += """
       milvus:
         condition: service_healthy"""
     
@@ -551,10 +527,6 @@ def build_webapp_setup(embedding_enabled, llm_enabled, webapp_port, uvicorn_work
       llm:
         condition: service_healthy"""
     
-    # Set service URLs based on what's enabled
-    embedding_url = "http://embedding" if embedding_enabled else "${BASE_EMBEDDING_URL}"
-    llm_url = "http://llm" if llm_enabled else "${BASE_LLM_URL}"
-    
     webapp_setup = f"""
   webapp:
     build:
@@ -562,17 +534,24 @@ def build_webapp_setup(embedding_enabled, llm_enabled, webapp_port, uvicorn_work
       dockerfile: Dockerfile
     container_name: webapp-faith
     ports:
-      - "{webapp_port}:{webapp_port}"
+      - "{webapp_port}:8000"
     env_file:
       - .env
     environment:
+      DJANGO_DEBUG: {django_debug}
+      DJANGO_SECRET_KEY: '{django_secret_key}'
+      DJANGO_ALLOWED_HOSTS: '{django_allowed_hosts}'
       POSTGRES_HOST: postgres
-      MILVUS_URL: http://milvus
+      POSTGRES_PORT: {postgres_port}
+      POSTGRES_USER: {postgres_user}
+      POSTGRES_PASSWORD: {postgres_password}
+      POSTGRES_DATABASE: {postgres_database}
+      MILVUS_URL: {milvus_url}
       BASE_EMBEDDING_URL: {embedding_url}
       BASE_LLM_URL: {llm_url}
-    command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port {webapp_port} --workers {uvicorn_workers}"
+    command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers {uvicorn_workers}"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{webapp_port}/healthcheck/"]
+      test: ["CMD", "curl", "-f", "http://webapp:8000/healthcheck/"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -619,7 +598,7 @@ exec su faith_user -c "uvicorn fAIth.asgi:application --host 0.0.0.0 --port {web
 # Main Function - Builds runner configuration based on driver/runner/device
 # ============================================================================
 
-def build_docker_compose(llm_port, model_id, embedding, max_context_length, runner, gpu_type, driver, llama_cpp_gpu_layers, llama_cpp_concurrency, vllm_enforce_eager, start_period, interval, timeout, retries):
+def build_docker_compose(llm_port, model_id, embedding, max_context_length, runner, gpu_type, driver, llama_cpp_gpu_layers, llama_cpp_concurrency, vllm_enforce_eager, hf_token, start_period, interval, timeout, retries):
     """
     Build the docker compose configuration for LLM or embedding service.
 
@@ -637,6 +616,7 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
         llama_cpp_gpu_layers: Number of layers to offload to GPU (llama.cpp)
         llama_cpp_concurrency: Number of concurrent requests (llama.cpp)
         vllm_enforce_eager: Enforce eager execution mode (vLLM)
+        hf_token: HuggingFace API token for model access
         start_period, interval, timeout, retries: Healthcheck parameters
 
     Returns:
@@ -686,13 +666,13 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
         if runner == "ollama":
             runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup="", ollama_force_cpu="OLLAMA_NUM_GPU=0", ollama_image="ollama/ollama:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server", hf_token=HF_TOKEN, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", vllm_enforce_eager=vllm_enforce_eager, hf_token=HF_TOKEN, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", hf_token=HF_TOKEN, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", hf_token=hf_token, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
     
     # ========================================================================
     # CUDA Driver - NVIDIA GPU acceleration
@@ -701,17 +681,17 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
     elif driver == "cuda":
         # Validate CUDA only works with NVIDIA GPUs
         if gpu_type != "nvidia":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Format runner templates with CUDA GPU support
         if runner == "ollama":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup=NVIDIA_SETUP, ollama_force_cpu="", ollama_image="ollama/ollama:latest", model_type=model_type)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup=NVIDIA_SETUP, ollama_force_cpu="", ollama_image="ollama/ollama:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-cuda", hf_token=HF_TOKEN, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-cuda", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=HF_TOKEN, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, hf_token=HF_TOKEN, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, hf_token=hf_token, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         else:
             raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`")
     
@@ -722,19 +702,19 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
     elif driver == "rocm":
         # Validate ROCM only works with AMD GPUs
         if gpu_type != "amd":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Format runner templates with ROCM GPU support
         if runner == "ollama":
             runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup=AMD_SETUP, ollama_force_cpu="", ollama_image="ollama/ollama:rocm", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-rocm", hf_token=HF_TOKEN, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-rocm", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=HF_TOKEN, vllm_image="rocm/vllm:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="rocm/vllm:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, hf_token=HF_TOKEN, sglang_image="lmsysorg/sglang:dsv32-rocm", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, hf_token=hf_token, sglang_image="lmsysorg/sglang:dsv32-rocm", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
     
     # ========================================================================
     # VULKAN Driver - Cross-platform GPU acceleration
@@ -743,16 +723,16 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
     elif driver == "vulkan":
         # Validate VULKAN doesn't support CPU
         if gpu_type == "cpu":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Only llama.cpp supports VULKAN currently
         if runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=gpu_setup, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-vulkan", hf_token=HF_TOKEN, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=gpu_setup, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-vulkan", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
     
     else:
-        raise ValueError(f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATBILITY_LIST}")
+        raise ValueError(f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
     print(f"Using `{runner}` with GPU type `{gpu_type}` on driver `{driver}`")
     return runner_setup
@@ -763,10 +743,28 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
 
 if __name__ == "__main__":
     # ========================================================================
-    # Load Embedding Service Configuration
+    # Load All Configuration from Environment Variables
     # ========================================================================
     
+    # Webapp configuration
+    WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT", 8000)).strip())
+    UVICORN_WORKERS = int(str(os.getenv("UVICORN_WORKERS", 1)).strip())
+    
+    # Postgres configuration
+    POSTGRES_HOST = str(os.getenv("POSTGRES_HOST", "")).strip()
+    DEFAULT_POSTGRES_PORT = "5432"
+    POSTGRES_PORT = str(os.getenv("POSTGRES_PORT", DEFAULT_POSTGRES_PORT)).strip()
+    POSTGRES_USER = str(os.getenv("POSTGRES_USER", "faith_user")).strip()
+    POSTGRES_PASSWORD = str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip()
+    POSTGRES_DATABASE = str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
+    
+    # Milvus configuration
+    MILVUS_URL = str(os.getenv("MILVUS_URL", "")).strip()
+    DEFAULT_MILVUS_PORT = "19530"
+    
+    # Embedding configuration
     EMBEDDING_PORT = str(os.getenv("EMBEDDING_PORT", "")).strip()
+    BASE_EMBEDDING_URL = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
     EMBEDDING_MODEL_ID = str(os.getenv("EMBEDDING_MODEL_ID", "Qwen/Qwen3-Embedding-0.6B")).strip()
     EMBEDDING_MAX_CONTEXT_LENGTH = int(str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH", 4096)).strip())
     EMBEDDING_MODEL_RUNNER = str(os.getenv("EMBEDDING_MODEL_RUNNER", "llama_cpp")).strip()
@@ -777,14 +775,11 @@ if __name__ == "__main__":
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if EMBEDDING_LLAMA_CPP_GPU_LAYERS == -1:
         EMBEDDING_LLAMA_CPP_GPU_LAYERS = 9999
-    EMBEDDING_VLLM_ENFORCE_EAGER = str(os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER", "False")).strip()
     EMBEDDING_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY", 2)).strip())
-
-    # ========================================================================
-    # Load LLM Service Configuration
-    # ========================================================================
     
+    # LLM configuration
     LLM_PORT = str(os.getenv("LLM_PORT", "")).strip()
+    BASE_LLM_URL = str(os.getenv("BASE_LLM_URL", "")).strip()
     LLM_MODEL_ID = str(os.getenv("LLM_MODEL_ID", "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M")).strip()
     LLM_MAX_CONTEXT_LENGTH = int(str(os.getenv("LLM_MAX_CONTEXT_LENGTH", 4096)).strip())
     LLM_MODEL_RUNNER = str(os.getenv("LLM_MODEL_RUNNER", "llama_cpp")).strip()
@@ -796,6 +791,21 @@ if __name__ == "__main__":
         LLM_LLAMA_CPP_GPU_LAYERS = 9999
     LLM_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY", 2)).strip())
     LLM_VLLM_ENFORCE_EAGER = str(os.getenv("LLM_VLLM_ENFORCE_EAGER", "False")).strip()
+    
+    # Django configuration
+    DJANGO_DEBUG = str(os.getenv("DJANGO_DEBUG", "False")).strip()
+    DJANGO_SECRET_KEY = str(os.getenv("DJANGO_SECRET_KEY", "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(")).strip()
+    DJANGO_ALLOWED_HOSTS = str(os.getenv("DJANGO_ALLOWED_HOSTS", "[\"127.0.0.1\", \"localhost\"]")).strip()
+    print(f"DJANGO_ALLOWED_HOSTS: {DJANGO_ALLOWED_HOSTS}")
+    
+    # HuggingFace configuration
+    HF_TOKEN = str(os.getenv("HF_TOKEN", "")).strip()
+    
+    # Healthcheck configuration
+    START_PERIOD = "3600s"
+    INTERVAL = "30s"
+    TIMEOUT = "30s"
+    RETRIES = 5
 
     # ========================================================================
     # Determine Which Services Are Enabled (Based on Port Configuration)
@@ -803,38 +813,80 @@ if __name__ == "__main__":
     
     # Services are only included if their ports are explicitly set
     # If port is empty, user will configure external service (e.g., OpenAI, OpenRouter)
-    embedding_enabled = bool(EMBEDDING_PORT)
-    llm_enabled = bool(LLM_PORT)
-    
-    if not embedding_enabled:
-        print("INFO: EMBEDDING_PORT not set. Webapp will use external embedding service (configure BASE_EMBEDDING_URL in .env)")
-    if not llm_enabled:
-        print("INFO: LLM_PORT not set. Webapp will use external LLM service (configure LLM_URL in .env)")
+    local_postgres_enabled = not bool(POSTGRES_HOST.strip())
+    local_milvus_enabled = not bool(MILVUS_URL.strip())
+    local_embedding_enabled = not bool(BASE_EMBEDDING_URL.strip())
+    local_llm_enabled = not bool(BASE_LLM_URL.strip())
 
+    if local_postgres_enabled:
+        print("INFO: POSTGRES_HOST not set. Webapp will use local PostgreSQL service (configure POSTGRES_HOST in .env)")
+    postgres_host = "postgres" if local_postgres_enabled else POSTGRES_HOST.replace("http://", "").replace("https://", "")
+    postgres_port = "5432" if local_postgres_enabled else POSTGRES_PORT
+    
+    if local_milvus_enabled:
+        print("INFO: MILVUS_URL not set. Webapp will use local Milvus service (configure MILVUS_URL in .env)")
+    milvus_url = f"http://milvus:{DEFAULT_MILVUS_PORT}" if local_milvus_enabled else MILVUS_URL
+    
+    if local_embedding_enabled:
+        print("INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service (configure BASE_EMBEDDING_URL in .env)")
+    embedding_url = f"http://embedding:{EMBEDDING_PORT}/v1" if local_embedding_enabled else BASE_EMBEDDING_URL
+
+    if local_llm_enabled:
+        print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service (configure BASE_LLM_URL in .env)")
+    llm_url = f"http://llm:{LLM_PORT}/v1" if local_llm_enabled else BASE_LLM_URL
+    
     # ========================================================================
     # Format Service Configuration Blocks
     # ========================================================================
     
-    postgres_block = POSTGRES_SETUP.format(postgres_port=POSTGRES_PORT, postgres_user=POSTGRES_USER, postgres_password=POSTGRES_PASSWORD, postgres_database=POSTGRES_DATABASE, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
-    etcd_block = ETCD_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
-    seaweedfs_block = SEAWEEDFS_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    if local_postgres_enabled:
+        postgres_block = POSTGRES_SETUP.format(postgres_host=postgres_host, postgres_port=postgres_port, postgres_user=POSTGRES_USER, postgres_password=POSTGRES_PASSWORD, postgres_database=POSTGRES_DATABASE, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    else:
+        postgres_block = ""
+    
     # Build Milvus block with conditional embedding dependency
-    milvus_block = build_milvus_setup(milvus_port=MILVUS_PORT, embedding_enabled=embedding_enabled, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    if local_milvus_enabled:
+        etcd_block = ETCD_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        seaweedfs_block = SEAWEEDFS_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        milvus_block = build_milvus_setup(local_embedding_enabled=local_embedding_enabled, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    else:
+        etcd_block = ""
+        seaweedfs_block = ""
+        milvus_block = ""
     
     # Build embedding service block only if port is set
-    if embedding_enabled:
-        embedding_block = build_docker_compose(llm_port=EMBEDDING_PORT, model_id=EMBEDDING_MODEL_ID, embedding=True, max_context_length=EMBEDDING_MAX_CONTEXT_LENGTH, runner=EMBEDDING_MODEL_RUNNER, gpu_type=EMBEDDING_GPU_TYPE, driver=EMBEDDING_DRIVER, llama_cpp_gpu_layers=EMBEDDING_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=LLM_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=EMBEDDING_VLLM_ENFORCE_EAGER, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    if local_embedding_enabled:
+        embedding_block = build_docker_compose(llm_port=EMBEDDING_PORT, model_id=EMBEDDING_MODEL_ID, embedding=True, max_context_length=EMBEDDING_MAX_CONTEXT_LENGTH, runner=EMBEDDING_MODEL_RUNNER, gpu_type=EMBEDDING_GPU_TYPE, driver=EMBEDDING_DRIVER, llama_cpp_gpu_layers=EMBEDDING_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=EMBEDDING_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=EMBEDDING_VLLM_ENFORCE_EAGER, hf_token=HF_TOKEN, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
     else:
         embedding_block = ""
     
     # Build LLM service block only if port is set
-    if llm_enabled:
-        llm_block = build_docker_compose(llm_port=LLM_PORT, model_id=LLM_MODEL_ID, embedding=False, max_context_length=LLM_MAX_CONTEXT_LENGTH, runner=LLM_MODEL_RUNNER, gpu_type=LLM_GPU_TYPE, driver=LLM_DRIVER, llama_cpp_gpu_layers=LLM_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=LLM_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=LLM_VLLM_ENFORCE_EAGER, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    if local_llm_enabled:
+        llm_block = build_docker_compose(llm_port=LLM_PORT, model_id=LLM_MODEL_ID, embedding=False, max_context_length=LLM_MAX_CONTEXT_LENGTH, runner=LLM_MODEL_RUNNER, gpu_type=LLM_GPU_TYPE, driver=LLM_DRIVER, llama_cpp_gpu_layers=LLM_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=LLM_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=LLM_VLLM_ENFORCE_EAGER, hf_token=HF_TOKEN, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
     else:
         llm_block = ""
     
     # Build webapp with conditional dependencies based on enabled services
-    webapp_block = build_webapp_setup(embedding_enabled=embedding_enabled, llm_enabled=llm_enabled, webapp_port=WEBAPP_PORT, uvicorn_workers=UVICORN_WORKERS, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+    webapp_block = build_webapp_setup(
+        milvus_enabled=local_milvus_enabled,
+        milvus_url=milvus_url,
+        embedding_enabled=local_embedding_enabled,
+        embedding_url=embedding_url,
+        llm_enabled=local_llm_enabled,
+        llm_url=llm_url,
+        webapp_port=WEBAPP_PORT,
+        uvicorn_workers=UVICORN_WORKERS,
+        django_debug=DJANGO_DEBUG,
+        django_secret_key=DJANGO_SECRET_KEY,
+        django_allowed_hosts=DJANGO_ALLOWED_HOSTS,
+        postgres_port=postgres_port,
+        postgres_user=POSTGRES_USER,
+        postgres_password=POSTGRES_PASSWORD,
+        postgres_database=POSTGRES_DATABASE,
+        start_period=START_PERIOD, 
+        interval=INTERVAL, 
+        timeout=TIMEOUT, 
+        retries=RETRIES)
 
     # ========================================================================
     # Assemble Final Docker Compose Configuration

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -15,8 +15,7 @@ load_dotenv()
 # Compatibility Matrix - Shows valid driver/runner/device combinations
 # ============================================================================
 
-COMPATIBILITY_LIST = \
-"""
+COMPATIBILITY_LIST = """
 Drivers:
     - `cpu`
         Runners:
@@ -80,7 +79,7 @@ Drivers:
                     - `nvidia`
                     - `amd`
                     - `intel`
-""".lstrip('\n')
+""".lstrip("\n")
 
 # ============================================================================
 # Docker Compose Template - Main service composition
@@ -89,54 +88,67 @@ Drivers:
 DOCKER_COMPOSE_TPL = """
 services:
 {services}
-""".lstrip('\n')
+""".lstrip("\n")
 
 # ============================================================================
 # Helper Function - Builds service list with proper spacing
 # ============================================================================
 
-def build_services_section(postgres_setup, etcd_setup, seaweedfs_setup, milvus_setup, embedding_setup, llm_setup, webapp_setup):
+
+def build_services_section(
+    postgres_setup,
+    etcd_setup,
+    seaweedfs_setup,
+    milvus_setup,
+    embedding_setup,
+    llm_setup,
+    webapp_setup,
+):
     """
     Build the services section of docker-compose with proper spacing.
-    
+
     Only includes services with content, avoiding blank lines for disabled services.
-    
+
     Parameters:
-        postgres_setup, etcd_setup, seaweedfs_setup, milvus_setup: Always included
-        embedding_setup, llm_setup: Included only if non-empty
+        postgres_setup, etcd_setup, seaweedfs_setup, milvus_setup: Included only if non-empty (local service enabled)
+        embedding_setup, llm_setup: Included only if non-empty (local service enabled)
         webapp_setup: Always included (final service)
-    
+
     Returns:
         str: Formatted services section
     """
     services = []
-    
-    # Always include these services
-    services.append(postgres_setup.lstrip('\n').rstrip('\n'))
-    services.append(etcd_setup.lstrip('\n').rstrip('\n'))
-    services.append(seaweedfs_setup.lstrip('\n').rstrip('\n'))
-    services.append(milvus_setup.lstrip('\n').rstrip('\n'))
-    
+
+    # Conditionally include database and infrastructure services
+    if postgres_setup.strip():
+        services.append(postgres_setup.lstrip("\n").rstrip("\n"))
+    if etcd_setup.strip():
+        services.append(etcd_setup.lstrip("\n").rstrip("\n"))
+    if seaweedfs_setup.strip():
+        services.append(seaweedfs_setup.lstrip("\n").rstrip("\n"))
+    if milvus_setup.strip():
+        services.append(milvus_setup.lstrip("\n").rstrip("\n"))
+
     # Conditionally include embedding service
     if embedding_setup.strip():
-        services.append(embedding_setup.lstrip('\n').rstrip('\n'))
-    
+        services.append(embedding_setup.lstrip("\n").rstrip("\n"))
+
     # Conditionally include LLM service
     if llm_setup.strip():
-        services.append(llm_setup.lstrip('\n').rstrip('\n'))
-    
+        services.append(llm_setup.lstrip("\n").rstrip("\n"))
+
     # Always include webapp (final service)
-    services.append(webapp_setup.lstrip('\n').rstrip('\n'))
-    
+    services.append(webapp_setup.lstrip("\n").rstrip("\n"))
+
     # Join all services with double newline separator (blank line between services)
-    return '\n\n'.join(services)
+    return "\n\n".join(services)
+
 
 # ============================================================================
 # GPU Configuration Templates - Driver/device-specific setup
 # ============================================================================
 
-NVIDIA_SETUP = \
-"""
+NVIDIA_SETUP = """
     deploy:
       resources:
         reservations:
@@ -145,31 +157,28 @@ NVIDIA_SETUP = \
               device_ids:
                 - nvidia.com/gpu=all
               capabilities: [gpu]
-""".lstrip('\n')
+""".lstrip("\n")
 
-AMD_SETUP = \
-"""
+AMD_SETUP = """
     devices:
       - /dev/kfd
       - /dev/dri
     group_add: [video, render]
     security_opt:
       - seccomp=unconfined
-""".lstrip('\n')
+""".lstrip("\n")
 
-INTEL_SETUP = \
-"""
+INTEL_SETUP = """
     devices:
       - /dev/dri
     group_add: [video, render]
-""".lstrip('\n')
+""".lstrip("\n")
 
 # ============================================================================
 # Service Configuration Templates
 # ============================================================================
 
-POSTGRES_SETUP = \
-"""
+POSTGRES_SETUP = """
   postgres:
     container_name: postgres-faith
     image: postgres:latest
@@ -181,13 +190,13 @@ POSTGRES_SETUP = \
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/postgres:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "{postgres_user}", "-d", "{postgres_database}"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
-""".lstrip('\n')
+""".lstrip("\n")
 
-ETCD_SETUP = \
-"""
+ETCD_SETUP = """
   etcd:
     container_name: etcd-faith
     image: milvusdb/etcd:latest
@@ -204,14 +213,14 @@ ETCD_SETUP = \
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/etcd:/etcd
     healthcheck:
       test: ["CMD", "etcdctl", "endpoint", "health"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
-""".lstrip('\n')
+""".lstrip("\n")
 
 # SeaweedFS: distributed file storage for Milvus backups
-SEAWEEDFS_SETUP = \
-"""
+SEAWEEDFS_SETUP = """
   seaweedfs-master:
     container_name: seaweedfs-master-faith
     image: chrislusf/seaweedfs:4.03
@@ -220,6 +229,7 @@ SEAWEEDFS_SETUP = \
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/seaweedfs/master:/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-master:9333/cluster/status"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -232,6 +242,7 @@ SEAWEEDFS_SETUP = \
     command: 'volume -ip=seaweedfs-volume -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -port=8080 -metricsPort=9325 -dir=/data'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-volume:8080/status"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -245,6 +256,7 @@ SEAWEEDFS_SETUP = \
     command: 'filer -ip=seaweedfs-filer -master="seaweedfs-master:9333" -ip.bind=0.0.0.0 -metricsPort=9326'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://seaweedfs-filer:8888/"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -265,6 +277,7 @@ SEAWEEDFS_SETUP = \
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
       test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
+      start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
@@ -307,20 +320,23 @@ SEAWEEDFS_SETUP = \
     depends_on:
       seaweedfs-s3:
         condition: service_healthy
-""".lstrip('\n')
+""".lstrip("\n")
+
 
 # Milvus: vector database for semantic search
-def build_milvus_setup(local_embedding_enabled, start_period, interval, timeout, retries):
+def build_milvus_setup(
+    local_embedding_enabled, start_period, interval, timeout, retries
+):
     """
     Build Milvus configuration with optional embedding dependency.
-    
+
     Milvus only needs to depend on embedding if it's being used for building
     initial collections with embeddings during setup.
-    
+
     Parameters:
         embedding_enabled: True if EMBEDDING_PORT is set
         start_period, interval, timeout, retries: Healthcheck parameters
-    
+
     Returns:
         str: Formatted Milvus Docker Compose service configuration
     """
@@ -332,13 +348,13 @@ def build_milvus_setup(local_embedding_enabled, start_period, interval, timeout,
         condition: service_healthy
       seaweedfs-init:
         condition: service_completed_successfully"""
-    
+
     # Only depend on embedding if it's enabled (for initial collection building)
     if local_embedding_enabled:
         depends_on += """
       embedding:
         condition: service_healthy"""
-    
+
     milvus_setup = f"""
   milvus:
     container_name: milvus-faith
@@ -364,36 +380,35 @@ def build_milvus_setup(local_embedding_enabled, start_period, interval, timeout,
       - seccomp:unconfined
 {depends_on}
 """
-    return milvus_setup.lstrip('\n')
+    return milvus_setup.lstrip("\n")
+
 
 # ============================================================================
 # LLM Runner Configuration Templates - Ollama, llama.cpp, vLLM, SGLang
 # ============================================================================
 
-OLLAMA_SETUP = \
-"""
+OLLAMA_SETUP = """
   {model_type}:
     container_name: ollama-{model_type}-faith
     image: {ollama_image}
     volumes:
       - ${{DOCKER_VOLUME_DIRECTORY:-.}}/volumes/ollama:/root/.ollama
     environment:
-      OLLAMA_HOST: 0.0.0.0:{llm_port}
+      OLLAMA_HOST: 0.0.0.0:{model_port}
       OLLAMA_MODELS: /root/.ollama
       OLLAMA_KEEP_ALIVE: 24h
       {ollama_force_cpu}
     command: ["serve"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/api/tags"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{model_port}/api/tags"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
 {gpu_setup}
-""".lstrip('\n')
+""".lstrip("\n")
 
-LLAMA_CPP_SETUP = \
-"""
+LLAMA_CPP_SETUP = """
   {model_type}:
     container_name: llama-cpp-{model_type}-faith
     image: {llama_cpp_image}
@@ -403,18 +418,17 @@ LLAMA_CPP_SETUP = \
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
-    command: ["-hf", "{model_id}", "-c", "{max_context_length}", "-ngl", "{llama_cpp_gpu_layers}", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0", "--host", "0.0.0.0", "--port", "{llm_port}", "--cont-batching", "-np", "{llama_cpp_concurrency}", {embedding}]
+    command: ["-hf", "{model_id}", "-c", "{max_context_length}", "-ngl", "{llama_cpp_gpu_layers}", "--cache-type-k", "q8_0", "--cache-type-v", "q8_0", "--host", "0.0.0.0", "--port", "{model_port}", "--cont-batching", "-np", "{llama_cpp_concurrency}", {embedding}]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/health"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{model_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
 {gpu_setup}
-""".lstrip('\n')
+""".lstrip("\n")
 
-VLLM_SETUP = \
-"""
+VLLM_SETUP = """
   {model_type}:
     container_name: vllm-{model_type}-faith
     image: {vllm_image}
@@ -424,19 +438,18 @@ VLLM_SETUP = \
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
-    command: ["--model", "{model_id}", "--download-dir", "/root/.cache/huggingface", "--max-model-len", "{max_context_length}", "--dtype", "auto", "--enforce-eager", "{vllm_enforce_eager}", "--host", "0.0.0.0", "--port", "{llm_port}"]
+    command: ["--model", "{model_id}", "--download-dir", "/root/.cache/huggingface", "--max-model-len", "{max_context_length}", "--dtype", "auto", "--enforce-eager", "{vllm_enforce_eager}", "--host", "0.0.0.0", "--port", "{model_port}"]
     ipc: host
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://{model_type}:{llm_port}/health"]
+      test: ["CMD", "curl", "-f", "http://{model_type}:{model_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
 {gpu_setup}
-""".lstrip('\n')
+""".lstrip("\n")
 
-SGLANG_SETUP = \
-"""
+SGLANG_SETUP = """
   {model_type}:
     container_name: sglang-{model_type}-faith
     image: {sglang_image}
@@ -448,85 +461,102 @@ SGLANG_SETUP = \
       HF_TOKEN: {hf_token}
       HF_HOME: /root/.cache/huggingface
       HUGGINGFACE_HUB_CACHE: /root/.cache/huggingface
-    command: ["python", "-m", "sglang.launch_server", "--model-path", "{model_id}", "--max-total-tokens", "{max_context_length}", "--disable-cuda-graph", "--host", "0.0.0.0", "--port", "{llm_port}"]
+    command: ["python", "-m", "sglang.launch_server", "--model-path", "{model_id}", "--max-total-tokens", "{max_context_length}", "--disable-cuda-graph", "--host", "0.0.0.0", "--port", "{model_port}"]
     ipc: host
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{llm_port}/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:{model_port}/health"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
       retries: {retries}
 {gpu_setup}
-""".lstrip('\n')
+""".lstrip("\n")
 
 # ============================================================================
 # Webapp Service Configuration - Built conditionally based on enabled services
 # ============================================================================
 
+
 def build_webapp_setup(
-  milvus_enabled,
-  milvus_url,
-  embedding_enabled,
-  embedding_url,
-  llm_enabled,
-  llm_url,
-  webapp_port, 
-  uvicorn_workers, 
-  django_debug, 
-  django_secret_key, 
-  django_allowed_hosts, 
-  postgres_port, 
-  postgres_user, 
-  postgres_password, 
-  postgres_database, 
-  start_period, 
-  interval, 
-  timeout, 
-  retries):
+    postgres_enabled,
+    postgres_host,
+    postgres_port,
+    postgres_user,
+    postgres_password,
+    postgres_database,
+    milvus_enabled,
+    milvus_host,
+    milvus_port,
+    embedding_enabled,
+    embedding_url,
+    llm_enabled,
+    llm_url,
+    webapp_port,
+    uvicorn_workers,
+    django_debug,
+    django_secret_key,
+    django_allowed_hosts,
+    start_period,
+    interval,
+    timeout,
+    retries,
+):
     """
     Build webapp configuration with conditional service dependencies.
-    
+
     If embedding or LLM services are not enabled (ports not set), the webapp
     will use external services (e.g., OpenAI, OpenRouter) configured via .env.
-    
+
     Parameters:
-        milvus_enabled (bool): True if MILVUS_PORT is set
-        milvus_url: Complete Milvus URL
-        embedding_enabled (bool): True if EMBEDDING_PORT is set
-        llm_enabled (bool): True if LLM_PORT is set
+        postgres_enabled (bool): True if using local PostgreSQL service
+        postgres_host: Postgres host
+        postgres_port: Postgres port
+        postgres_user: Postgres user
+        postgres_password: Postgres password
+        postgres_database: Postgres database
+        milvus_enabled (bool): True if using local Milvus service
+        milvus_host: Milvus host
+        milvus_port: Milvus port
+        embedding_enabled (bool): True if using local embedding service
+        llm_enabled (bool): True if using local LLM service
         webapp_port: Port to expose webapp on
         uvicorn_workers: Number of uvicorn workers
         django_debug: Django debug mode
         django_secret_key: Django secret key
         django_allowed_hosts: Django allowed hosts
-        postgres_port: Postgres port
-        postgres_user: Postgres user
-        start_period, interval, timeout, retries: Healthcheck parameters
-    
+        start_period: Healthcheck start period
+        interval: Healthcheck interval
+        timeout: Healthcheck timeout
+        retries: Healthcheck retries
+
     Returns:
         str: Formatted webapp Docker Compose service configuration
     """
     # Build depends_on section based on enabled services
-    depends_on = """    depends_on:
-      postgres:
-        condition: service_healthy
-    """
-    
+    depends_on_services = []
+
+    if postgres_enabled:
+        depends_on_services.append("""      postgres:
+        condition: service_healthy""")
+
     if milvus_enabled:
-        depends_on += """
-      milvus:
-        condition: service_healthy"""
-    
+        depends_on_services.append("""      milvus:
+        condition: service_healthy""")
+
     if embedding_enabled:
-        depends_on += """
-      embedding:
-        condition: service_healthy"""
-    
+        depends_on_services.append("""      embedding:
+        condition: service_healthy""")
+
     if llm_enabled:
-        depends_on += """
-      llm:
-        condition: service_healthy"""
-    
+        depends_on_services.append("""      llm:
+        condition: service_healthy""")
+
+    # Only include depends_on section if there are dependencies
+    if depends_on_services:
+        depends_on = "    depends_on:\n" + "\n".join(depends_on_services) + "\n"
+    else:
+        depends_on = ""
+
     webapp_setup = f"""
   webapp:
     build:
@@ -541,12 +571,13 @@ def build_webapp_setup(
       DJANGO_DEBUG: {django_debug}
       DJANGO_SECRET_KEY: '{django_secret_key}'
       DJANGO_ALLOWED_HOSTS: '{django_allowed_hosts}'
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: {postgres_host}
       POSTGRES_PORT: {postgres_port}
       POSTGRES_USER: {postgres_user}
       POSTGRES_PASSWORD: {postgres_password}
       POSTGRES_DATABASE: {postgres_database}
-      MILVUS_URL: {milvus_url}
+      MILVUS_HOST: {milvus_host}
+      MILVUS_PORT: {milvus_port}
       BASE_EMBEDDING_URL: {embedding_url}
       BASE_LLM_URL: {llm_url}
     command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers {uvicorn_workers}"
@@ -560,14 +591,14 @@ def build_webapp_setup(
     volumes:
       - .:/app
 """
-    return webapp_setup.lstrip('\n')
+    return webapp_setup.lstrip("\n")
+
 
 # ============================================================================
 # Shell Entrypoint Script - Alternative startup sequence with permissions
 # ============================================================================
 
-SHELL_ENTRYPOINT = \
-"""
+SHELL_ENTRYPOINT = """
 #!/bin/sh
 
 set -euo
@@ -592,13 +623,30 @@ fi
 
 log "Starting application server as faith_user"
 exec su faith_user -c "uvicorn fAIth.asgi:application --host 0.0.0.0 --port {webapp_port} --workers {uvicorn_workers}"
-""".lstrip('\n')
+""".lstrip("\n")
 
 # ============================================================================
 # Main Function - Builds runner configuration based on driver/runner/device
 # ============================================================================
 
-def build_docker_compose(llm_port, model_id, embedding, max_context_length, runner, gpu_type, driver, llama_cpp_gpu_layers, llama_cpp_concurrency, vllm_enforce_eager, hf_token, start_period, interval, timeout, retries):
+
+def build_docker_compose(
+    model_port,
+    model_id,
+    embedding,
+    max_context_length,
+    runner,
+    gpu_type,
+    driver,
+    llama_cpp_gpu_layers,
+    llama_cpp_concurrency,
+    vllm_enforce_eager,
+    hf_token,
+    start_period,
+    interval,
+    timeout,
+    retries,
+):
     """
     Build the docker compose configuration for LLM or embedding service.
 
@@ -606,7 +654,7 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
     Validates compatibility and formats the configuration with provided parameters.
 
     Parameters:
-        llm_port: Port to expose the service on
+        model_port: Port to expose the service on
         model_id: HuggingFace model identifier
         embedding: True for embedding service, False for LLM
         max_context_length: Maximum context window for the model
@@ -623,9 +671,9 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
         str: Formatted Docker Compose service configuration
     """
     # Determine if building embedding or LLM service
-    embedding_setup = '"--embedding"' if embedding else ''
+    embedding_setup = '"--embedding"' if embedding else ""
     model_type = "embedding" if embedding else "llm"
-    
+
     # Select template based on runner type
     if runner == "llama_cpp":
         runner_setup = LLAMA_CPP_SETUP
@@ -649,93 +697,280 @@ def build_docker_compose(llm_port, model_id, embedding, max_context_length, runn
         gpu_setup = ""
     else:
         raise ValueError(f"Invalid GPU type: `{gpu_type}`")
-    
+
     # ========================================================================
     # CPU Driver - Uses software-based inference
     # ========================================================================
-    
+
     if driver == "cpu":
         # Warn if user specified GPU type but selected CPU driver
         if gpu_type != "cpu":
             if embedding:
-                print(f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `EMBEDDING_DRIVER` environment variable.")
+                print(
+                    f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `EMBEDDING_DRIVER` environment variable."
+                )
             else:
-                print(f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `LLM_DRIVER` environment variable.")
+                print(
+                    f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `LLM_DRIVER` environment variable."
+                )
 
         # Format runner template with CPU-specific configuration
         if runner == "ollama":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup="", ollama_force_cpu="OLLAMA_NUM_GPU=0", ollama_image="ollama/ollama:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                gpu_setup="",
+                ollama_force_cpu="OLLAMA_NUM_GPU=0",
+                ollama_image="ollama/ollama:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup="",
+                llama_cpp_gpu_layers=llama_cpp_gpu_layers,
+                llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server",
+                hf_token=hf_token,
+                embedding=embedding_setup,
+                llama_cpp_concurrency=llama_cpp_concurrency,
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup="",
+                vllm_enforce_eager=vllm_enforce_eager,
+                hf_token=hf_token,
+                vllm_image="vllm/vllm-openai:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup="", hf_token=hf_token, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup="",
+                hf_token=hf_token,
+                sglang_image="lmsysorg/sglang:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
-    
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
+
     # ========================================================================
     # CUDA Driver - NVIDIA GPU acceleration
     # ========================================================================
-    
+
     elif driver == "cuda":
         # Validate CUDA only works with NVIDIA GPUs
         if gpu_type != "nvidia":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
 
         # Format runner templates with CUDA GPU support
         if runner == "ollama":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup=NVIDIA_SETUP, ollama_force_cpu="", ollama_image="ollama/ollama:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                gpu_setup=NVIDIA_SETUP,
+                ollama_force_cpu="",
+                ollama_image="ollama/ollama:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-cuda", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=NVIDIA_SETUP,
+                llama_cpp_gpu_layers=llama_cpp_gpu_layers,
+                llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-cuda",
+                hf_token=hf_token,
+                embedding=embedding_setup,
+                llama_cpp_concurrency=llama_cpp_concurrency,
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="vllm/vllm-openai:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=NVIDIA_SETUP,
+                vllm_enforce_eager=vllm_enforce_eager,
+                hf_token=hf_token,
+                vllm_image="vllm/vllm-openai:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=NVIDIA_SETUP, hf_token=hf_token, sglang_image="lmsysorg/sglang:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=NVIDIA_SETUP,
+                hf_token=hf_token,
+                sglang_image="lmsysorg/sglang:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         else:
             raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`")
-    
+
     # ========================================================================
     # ROCM Driver - AMD GPU acceleration
     # ========================================================================
-    
+
     elif driver == "rocm":
         # Validate ROCM only works with AMD GPUs
         if gpu_type != "amd":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
 
         # Format runner templates with ROCM GPU support
         if runner == "ollama":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, gpu_setup=AMD_SETUP, ollama_force_cpu="", ollama_image="ollama/ollama:rocm", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                gpu_setup=AMD_SETUP,
+                ollama_force_cpu="",
+                ollama_image="ollama/ollama:rocm",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-rocm", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=AMD_SETUP,
+                llama_cpp_gpu_layers=llama_cpp_gpu_layers,
+                llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-rocm",
+                hf_token=hf_token,
+                embedding=embedding_setup,
+                llama_cpp_concurrency=llama_cpp_concurrency,
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "vllm":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, vllm_enforce_eager=vllm_enforce_eager, hf_token=hf_token, vllm_image="rocm/vllm:latest", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=AMD_SETUP,
+                vllm_enforce_eager=vllm_enforce_eager,
+                hf_token=hf_token,
+                vllm_image="rocm/vllm:latest",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         elif runner == "sglang":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=AMD_SETUP, hf_token=hf_token, sglang_image="lmsysorg/sglang:dsv32-rocm", model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=AMD_SETUP,
+                hf_token=hf_token,
+                sglang_image="lmsysorg/sglang:dsv32-rocm",
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
-    
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
+
     # ========================================================================
     # VULKAN Driver - Cross-platform GPU acceleration
     # ========================================================================
-    
+
     elif driver == "vulkan":
         # Validate VULKAN doesn't support CPU
         if gpu_type == "cpu":
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
 
         # Only llama.cpp supports VULKAN currently
         if runner == "llama_cpp":
-            runner_setup = runner_setup.format(llm_port=llm_port, model_id=model_id, max_context_length=max_context_length, gpu_setup=gpu_setup, llama_cpp_gpu_layers=llama_cpp_gpu_layers, llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-vulkan", hf_token=hf_token, embedding=embedding_setup, llama_cpp_concurrency=llama_cpp_concurrency, model_type=model_type, start_period=start_period, interval=interval, timeout=timeout, retries=retries)
+            runner_setup = runner_setup.format(
+                model_port=model_port,
+                model_id=model_id,
+                max_context_length=max_context_length,
+                gpu_setup=gpu_setup,
+                llama_cpp_gpu_layers=llama_cpp_gpu_layers,
+                llama_cpp_image="ghcr.io/ggml-org/llama.cpp:server-vulkan",
+                hf_token=hf_token,
+                embedding=embedding_setup,
+                llama_cpp_concurrency=llama_cpp_concurrency,
+                model_type=model_type,
+                start_period=start_period,
+                interval=interval,
+                timeout=timeout,
+                retries=retries,
+            )
         else:
-            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
-    
+            raise ValueError(
+                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+            )
+
     else:
-        raise ValueError(f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
+        raise ValueError(
+            f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
+        )
 
     print(f"Using `{runner}` with GPU type `{gpu_type}` on driver `{driver}`")
     return runner_setup
+
 
 # ============================================================================
 # Main Entry Point - Generates docker-compose.yml and entrypoint script
@@ -745,62 +980,88 @@ if __name__ == "__main__":
     # ========================================================================
     # Load All Configuration from Environment Variables
     # ========================================================================
-    
+
     # Webapp configuration
     WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT", 8000)).strip())
     UVICORN_WORKERS = int(str(os.getenv("UVICORN_WORKERS", 1)).strip())
-    
+
     # Postgres configuration
     POSTGRES_HOST = str(os.getenv("POSTGRES_HOST", "")).strip()
-    DEFAULT_POSTGRES_PORT = "5432"
-    POSTGRES_PORT = str(os.getenv("POSTGRES_PORT", DEFAULT_POSTGRES_PORT)).strip()
+    POSTGRES_PORT = str(os.getenv("POSTGRES_PORT", "5432")).strip()
     POSTGRES_USER = str(os.getenv("POSTGRES_USER", "faith_user")).strip()
-    POSTGRES_PASSWORD = str(os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")).strip()
+    POSTGRES_PASSWORD = str(
+        os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")
+    ).strip()
     POSTGRES_DATABASE = str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
-    
+
     # Milvus configuration
-    MILVUS_URL = str(os.getenv("MILVUS_URL", "")).strip()
-    DEFAULT_MILVUS_PORT = "19530"
-    
+    MILVUS_HOST = str(os.getenv("MILVUS_HOST", "")).strip()
+    MILVUS_PORT = str(os.getenv("MILVUS_PORT", "19530")).strip()
+
     # Embedding configuration
     EMBEDDING_PORT = str(os.getenv("EMBEDDING_PORT", "")).strip()
     BASE_EMBEDDING_URL = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
-    EMBEDDING_MODEL_ID = str(os.getenv("EMBEDDING_MODEL_ID", "Qwen/Qwen3-Embedding-0.6B")).strip()
-    EMBEDDING_MAX_CONTEXT_LENGTH = int(str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH", 4096)).strip())
-    EMBEDDING_MODEL_RUNNER = str(os.getenv("EMBEDDING_MODEL_RUNNER", "llama_cpp")).strip()
+    EMBEDDING_MODEL_ID = str(
+        os.getenv("EMBEDDING_MODEL_ID", "Qwen/Qwen3-Embedding-0.6B")
+    ).strip()
+    EMBEDDING_MAX_CONTEXT_LENGTH = int(
+        str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH", 4096)).strip()
+    )
+    EMBEDDING_MODEL_RUNNER = str(
+        os.getenv("EMBEDDING_MODEL_RUNNER", "llama_cpp")
+    ).strip()
     EMBEDDING_GPU_TYPE = str(os.getenv("EMBEDDING_GPU_TYPE", "cpu")).strip()
     EMBEDDING_DRIVER = str(os.getenv("EMBEDDING_DRIVER", "cpu")).strip()
-    EMBEDDING_VLLM_ENFORCE_EAGER = str(os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER", "False")).strip()
-    EMBEDDING_LLAMA_CPP_GPU_LAYERS = int(str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS", 0)).strip())
+    EMBEDDING_VLLM_ENFORCE_EAGER = str(
+        os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER", "False")
+    ).strip()
+    EMBEDDING_LLAMA_CPP_GPU_LAYERS = int(
+        str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS", 0)).strip()
+    )
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if EMBEDDING_LLAMA_CPP_GPU_LAYERS == -1:
         EMBEDDING_LLAMA_CPP_GPU_LAYERS = 9999
-    EMBEDDING_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY", 2)).strip())
-    
+    EMBEDDING_LLAMA_CPP_CONCURRENCY = int(
+        str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY", 2)).strip()
+    )
+
     # LLM configuration
     LLM_PORT = str(os.getenv("LLM_PORT", "")).strip()
     BASE_LLM_URL = str(os.getenv("BASE_LLM_URL", "")).strip()
-    LLM_MODEL_ID = str(os.getenv("LLM_MODEL_ID", "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M")).strip()
+    LLM_MODEL_ID = str(
+        os.getenv("LLM_MODEL_ID", "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M")
+    ).strip()
     LLM_MAX_CONTEXT_LENGTH = int(str(os.getenv("LLM_MAX_CONTEXT_LENGTH", 4096)).strip())
     LLM_MODEL_RUNNER = str(os.getenv("LLM_MODEL_RUNNER", "llama_cpp")).strip()
     LLM_GPU_TYPE = str(os.getenv("LLM_GPU_TYPE", "cpu")).strip()
     LLM_DRIVER = str(os.getenv("LLM_DRIVER", "cpu")).strip()
-    LLM_LLAMA_CPP_GPU_LAYERS = int(str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS", 0)).strip())
+    LLM_LLAMA_CPP_GPU_LAYERS = int(
+        str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS", 0)).strip()
+    )
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if LLM_LLAMA_CPP_GPU_LAYERS == -1:
         LLM_LLAMA_CPP_GPU_LAYERS = 9999
-    LLM_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY", 2)).strip())
+    LLM_LLAMA_CPP_CONCURRENCY = int(
+        str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY", 2)).strip()
+    )
     LLM_VLLM_ENFORCE_EAGER = str(os.getenv("LLM_VLLM_ENFORCE_EAGER", "False")).strip()
-    
+
     # Django configuration
     DJANGO_DEBUG = str(os.getenv("DJANGO_DEBUG", "False")).strip()
-    DJANGO_SECRET_KEY = str(os.getenv("DJANGO_SECRET_KEY", "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(")).strip()
-    DJANGO_ALLOWED_HOSTS = str(os.getenv("DJANGO_ALLOWED_HOSTS", "[\"127.0.0.1\", \"localhost\"]")).strip()
+    DJANGO_SECRET_KEY = str(
+        os.getenv(
+            "DJANGO_SECRET_KEY",
+            "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(",
+        )
+    ).strip()
+    DJANGO_ALLOWED_HOSTS = str(
+        os.getenv("DJANGO_ALLOWED_HOSTS", '["127.0.0.1", "localhost"]')
+    ).strip()
     print(f"DJANGO_ALLOWED_HOSTS: {DJANGO_ALLOWED_HOSTS}")
-    
+
     # HuggingFace configuration
     HF_TOKEN = str(os.getenv("HF_TOKEN", "")).strip()
-    
+
     # Healthcheck configuration
     START_PERIOD = "3600s"
     INTERVAL = "30s"
@@ -810,66 +1071,148 @@ if __name__ == "__main__":
     # ========================================================================
     # Determine Which Services Are Enabled (Based on Port Configuration)
     # ========================================================================
-    
+
     # Services are only included if their ports are explicitly set
     # If port is empty, user will configure external service (e.g., OpenAI, OpenRouter)
     local_postgres_enabled = not bool(POSTGRES_HOST.strip())
-    local_milvus_enabled = not bool(MILVUS_URL.strip())
+    local_milvus_enabled = not bool(MILVUS_HOST.strip())
     local_embedding_enabled = not bool(BASE_EMBEDDING_URL.strip())
     local_llm_enabled = not bool(BASE_LLM_URL.strip())
 
+    # Build Postgres host and port
     if local_postgres_enabled:
-        print("INFO: POSTGRES_HOST not set. Webapp will use local PostgreSQL service (configure POSTGRES_HOST in .env)")
-    postgres_host = "postgres" if local_postgres_enabled else POSTGRES_HOST.replace("http://", "").replace("https://", "")
+        print("INFO: POSTGRES_HOST not set. Webapp will use local PostgreSQL service.")
+    postgres_host = "postgres" if local_postgres_enabled else POSTGRES_HOST
     postgres_port = "5432" if local_postgres_enabled else POSTGRES_PORT
-    
-    if local_milvus_enabled:
-        print("INFO: MILVUS_URL not set. Webapp will use local Milvus service (configure MILVUS_URL in .env)")
-    milvus_url = f"http://milvus:{DEFAULT_MILVUS_PORT}" if local_milvus_enabled else MILVUS_URL
-    
-    if local_embedding_enabled:
-        print("INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service (configure BASE_EMBEDDING_URL in .env)")
-    embedding_url = f"http://embedding:{EMBEDDING_PORT}/v1" if local_embedding_enabled else BASE_EMBEDDING_URL
 
+    # If Postgres host is a valid URL, remove the protocol prefix
+    if postgres_host.startswith(("http://", "https://")):
+        postgres_host = postgres_host.replace("http://", "").replace("https://", "")
+
+    # Build Milvus host and port
+    if local_milvus_enabled:
+        print("INFO: MILVUS_HOST not set. Webapp will use local Milvus service.")
+    milvus_host = "milvus" if local_milvus_enabled else MILVUS_HOST
+    milvus_port = "19530" if local_milvus_enabled else MILVUS_PORT
+
+    # If Milvus host is not a valid URL, add http:// prefix
+    if not milvus_host.startswith(("http://", "https://")):
+        milvus_host = f"http://{milvus_host}"
+
+    # Build embedding URL
+    if local_embedding_enabled:
+        print(
+            "INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service."
+        )
+    embedding_url = (
+        f"http://embedding:{EMBEDDING_PORT}/v1"
+        if local_embedding_enabled
+        else BASE_EMBEDDING_URL
+    )
+
+    # Build LLM URL
     if local_llm_enabled:
-        print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service (configure BASE_LLM_URL in .env)")
+        print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service.")
     llm_url = f"http://llm:{LLM_PORT}/v1" if local_llm_enabled else BASE_LLM_URL
-    
+
     # ========================================================================
     # Format Service Configuration Blocks
     # ========================================================================
-    
+
     if local_postgres_enabled:
-        postgres_block = POSTGRES_SETUP.format(postgres_host=postgres_host, postgres_port=postgres_port, postgres_user=POSTGRES_USER, postgres_password=POSTGRES_PASSWORD, postgres_database=POSTGRES_DATABASE, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        postgres_block = POSTGRES_SETUP.format(
+            postgres_user=POSTGRES_USER,
+            postgres_password=POSTGRES_PASSWORD,
+            postgres_database=POSTGRES_DATABASE,
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
     else:
         postgres_block = ""
-    
+
     # Build Milvus block with conditional embedding dependency
     if local_milvus_enabled:
-        etcd_block = ETCD_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
-        seaweedfs_block = SEAWEEDFS_SETUP.format(start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
-        milvus_block = build_milvus_setup(local_embedding_enabled=local_embedding_enabled, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        etcd_block = ETCD_SETUP.format(
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
+        seaweedfs_block = SEAWEEDFS_SETUP.format(
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
+        milvus_block = build_milvus_setup(
+            local_embedding_enabled=local_embedding_enabled,
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
     else:
         etcd_block = ""
         seaweedfs_block = ""
         milvus_block = ""
-    
+
     # Build embedding service block only if port is set
     if local_embedding_enabled:
-        embedding_block = build_docker_compose(llm_port=EMBEDDING_PORT, model_id=EMBEDDING_MODEL_ID, embedding=True, max_context_length=EMBEDDING_MAX_CONTEXT_LENGTH, runner=EMBEDDING_MODEL_RUNNER, gpu_type=EMBEDDING_GPU_TYPE, driver=EMBEDDING_DRIVER, llama_cpp_gpu_layers=EMBEDDING_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=EMBEDDING_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=EMBEDDING_VLLM_ENFORCE_EAGER, hf_token=HF_TOKEN, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        embedding_block = build_docker_compose(
+            model_port=EMBEDDING_PORT,
+            model_id=EMBEDDING_MODEL_ID,
+            embedding=True,
+            max_context_length=EMBEDDING_MAX_CONTEXT_LENGTH,
+            runner=EMBEDDING_MODEL_RUNNER,
+            gpu_type=EMBEDDING_GPU_TYPE,
+            driver=EMBEDDING_DRIVER,
+            llama_cpp_gpu_layers=EMBEDDING_LLAMA_CPP_GPU_LAYERS,
+            llama_cpp_concurrency=EMBEDDING_LLAMA_CPP_CONCURRENCY,
+            vllm_enforce_eager=EMBEDDING_VLLM_ENFORCE_EAGER,
+            hf_token=HF_TOKEN,
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
     else:
         embedding_block = ""
-    
+
     # Build LLM service block only if port is set
     if local_llm_enabled:
-        llm_block = build_docker_compose(llm_port=LLM_PORT, model_id=LLM_MODEL_ID, embedding=False, max_context_length=LLM_MAX_CONTEXT_LENGTH, runner=LLM_MODEL_RUNNER, gpu_type=LLM_GPU_TYPE, driver=LLM_DRIVER, llama_cpp_gpu_layers=LLM_LLAMA_CPP_GPU_LAYERS, llama_cpp_concurrency=LLM_LLAMA_CPP_CONCURRENCY, vllm_enforce_eager=LLM_VLLM_ENFORCE_EAGER, hf_token=HF_TOKEN, start_period=START_PERIOD, interval=INTERVAL, timeout=TIMEOUT, retries=RETRIES)
+        llm_block = build_docker_compose(
+            model_port=LLM_PORT,
+            model_id=LLM_MODEL_ID,
+            embedding=False,
+            max_context_length=LLM_MAX_CONTEXT_LENGTH,
+            runner=LLM_MODEL_RUNNER,
+            gpu_type=LLM_GPU_TYPE,
+            driver=LLM_DRIVER,
+            llama_cpp_gpu_layers=LLM_LLAMA_CPP_GPU_LAYERS,
+            llama_cpp_concurrency=LLM_LLAMA_CPP_CONCURRENCY,
+            vllm_enforce_eager=LLM_VLLM_ENFORCE_EAGER,
+            hf_token=HF_TOKEN,
+            start_period=START_PERIOD,
+            interval=INTERVAL,
+            timeout=TIMEOUT,
+            retries=RETRIES,
+        )
     else:
         llm_block = ""
-    
+
     # Build webapp with conditional dependencies based on enabled services
     webapp_block = build_webapp_setup(
+        postgres_enabled=local_postgres_enabled,
+        postgres_host=postgres_host,
+        postgres_port=postgres_port,
+        postgres_user=POSTGRES_USER,
+        postgres_password=POSTGRES_PASSWORD,
+        postgres_database=POSTGRES_DATABASE,
         milvus_enabled=local_milvus_enabled,
-        milvus_url=milvus_url,
+        milvus_host=milvus_host,
+        milvus_port=milvus_port,
         embedding_enabled=local_embedding_enabled,
         embedding_url=embedding_url,
         llm_enabled=local_llm_enabled,
@@ -879,19 +1222,16 @@ if __name__ == "__main__":
         django_debug=DJANGO_DEBUG,
         django_secret_key=DJANGO_SECRET_KEY,
         django_allowed_hosts=DJANGO_ALLOWED_HOSTS,
-        postgres_port=postgres_port,
-        postgres_user=POSTGRES_USER,
-        postgres_password=POSTGRES_PASSWORD,
-        postgres_database=POSTGRES_DATABASE,
-        start_period=START_PERIOD, 
-        interval=INTERVAL, 
-        timeout=TIMEOUT, 
-        retries=RETRIES)
+        start_period=START_PERIOD,
+        interval=INTERVAL,
+        timeout=TIMEOUT,
+        retries=RETRIES,
+    )
 
     # ========================================================================
     # Assemble Final Docker Compose Configuration
     # ========================================================================
-    
+
     # Build services section with proper spacing (no gaps for disabled services)
     services_section = build_services_section(
         postgres_setup=postgres_block,
@@ -900,18 +1240,24 @@ if __name__ == "__main__":
         milvus_setup=milvus_block,
         embedding_setup=embedding_block,
         llm_setup=llm_block,
-        webapp_setup=webapp_block
+        webapp_setup=webapp_block,
     )
-    
+
     docker_compose_str = DOCKER_COMPOSE_TPL.format(services=services_section)
-    
+
     # Prepare shell entrypoint script with proper formatting
-    shell_entrypoint_str = SHELL_ENTRYPOINT.format(webapp_port=WEBAPP_PORT, uvicorn_workers=UVICORN_WORKERS).lstrip('\n').rstrip('\n')
+    shell_entrypoint_str = (
+        SHELL_ENTRYPOINT.format(
+            webapp_port=WEBAPP_PORT, uvicorn_workers=UVICORN_WORKERS
+        )
+        .lstrip("\n")
+        .rstrip("\n")
+    )
 
     # ========================================================================
     # Write Generated Files
     # ========================================================================
-    
+
     with Path("docker-compose.yml").open("w", encoding="utf-8") as f:
         f.write(docker_compose_str)
 

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -325,7 +325,11 @@ SEAWEEDFS_SETUP = """
 
 # Milvus: vector database for semantic search
 def build_milvus_setup(
-    local_embedding_enabled, start_period, interval, timeout, retries
+    local_embedding_enabled,
+    start_period,
+    interval,
+    timeout,
+    retries,
 ):
     """
     Build Milvus configuration with optional embedding dependency.
@@ -681,13 +685,9 @@ def build_docker_compose(
         # Warn if user specified GPU type but selected CPU driver
         if gpu_type != "cpu":
             if embedding:
-                print(
-                    f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `EMBEDDING_DRIVER` environment variable."
-                )
+                print(f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `EMBEDDING_DRIVER` environment variable.")
             else:
-                print(
-                    f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `LLM_DRIVER` environment variable."
-                )
+                print(f"WARNING: Using CPU driver with GPU type `{gpu_type}`. If this is not intended, please check your `LLM_DRIVER` environment variable.")
 
         # Format runner template with CPU-specific configuration
         if runner == "ollama":
@@ -750,9 +750,7 @@ def build_docker_compose(
                 retries=retries,
             )
         else:
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
     # ========================================================================
     # CUDA Driver - NVIDIA GPU acceleration
@@ -761,9 +759,7 @@ def build_docker_compose(
     elif driver == "cuda":
         # Validate CUDA only works with NVIDIA GPUs
         if gpu_type != "nvidia":
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Format runner templates with CUDA GPU support
         if runner == "ollama":
@@ -835,9 +831,7 @@ def build_docker_compose(
     elif driver == "rocm":
         # Validate ROCM only works with AMD GPUs
         if gpu_type != "amd":
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Format runner templates with ROCM GPU support
         if runner == "ollama":
@@ -900,9 +894,7 @@ def build_docker_compose(
                 retries=retries,
             )
         else:
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
     # ========================================================================
     # VULKAN Driver - Cross-platform GPU acceleration
@@ -911,9 +903,7 @@ def build_docker_compose(
     elif driver == "vulkan":
         # Validate VULKAN doesn't support CPU
         if gpu_type == "cpu":
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
         # Only llama.cpp supports VULKAN currently
         if runner == "llama_cpp":
@@ -934,14 +924,10 @@ def build_docker_compose(
                 retries=retries,
             )
         else:
-            raise ValueError(
-                f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-            )
+            raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
     else:
-        raise ValueError(
-            f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}"
-        )
+        raise ValueError(f"Invalid driver: `{driver}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
     print(f"Using `{runner}` with GPU type `{gpu_type}` on driver `{driver}`")
     return runner_setup
@@ -974,51 +960,31 @@ if __name__ == "__main__":
     # Embedding configuration
     EMBEDDING_PORT = str(os.getenv("EMBEDDING_PORT") or "").strip()
     BASE_EMBEDDING_URL = str(os.getenv("BASE_EMBEDDING_URL") or "").strip()
-    EMBEDDING_MODEL_ID = str(
-        os.getenv("EMBEDDING_MODEL_ID") or "Qwen/Qwen3-Embedding-0.6B"
-    ).strip()
-    EMBEDDING_MAX_CONTEXT_LENGTH = int(
-        str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH") or 4096).strip()
-    )
-    EMBEDDING_MODEL_RUNNER = str(
-        os.getenv("EMBEDDING_MODEL_RUNNER") or "llama_cpp"
-    ).strip()
+    EMBEDDING_MODEL_ID = str(os.getenv("EMBEDDING_MODEL_ID") or "Qwen/Qwen3-Embedding-0.6B").strip()
+    EMBEDDING_MAX_CONTEXT_LENGTH = int(str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH") or 4096).strip())
+    EMBEDDING_MODEL_RUNNER = str(os.getenv("EMBEDDING_MODEL_RUNNER") or "llama_cpp").strip()
     EMBEDDING_GPU_TYPE = str(os.getenv("EMBEDDING_GPU_TYPE") or "cpu").strip()
     EMBEDDING_DRIVER = str(os.getenv("EMBEDDING_DRIVER") or "cpu").strip()
-    EMBEDDING_VLLM_ENFORCE_EAGER = str(
-        os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER") or "False"
-    ).strip()
-    EMBEDDING_LLAMA_CPP_GPU_LAYERS = int(
-        str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS") or 0).strip()
-    )
+    EMBEDDING_VLLM_ENFORCE_EAGER = str(os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER") or "False").strip()
+    EMBEDDING_LLAMA_CPP_GPU_LAYERS = int(str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS") or 0).strip())
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if EMBEDDING_LLAMA_CPP_GPU_LAYERS == -1:
         EMBEDDING_LLAMA_CPP_GPU_LAYERS = 9999
-    EMBEDDING_LLAMA_CPP_CONCURRENCY = int(
-        str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY") or 2).strip()
-    )
+    EMBEDDING_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY") or 2).strip())
 
     # LLM configuration
     LLM_PORT = str(os.getenv("LLM_PORT") or "").strip()
     BASE_LLM_URL = str(os.getenv("BASE_LLM_URL") or "").strip()
-    LLM_MODEL_ID = str(
-        os.getenv("LLM_MODEL_ID") or "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M"
-    ).strip()
-    LLM_MAX_CONTEXT_LENGTH = int(
-        str(os.getenv("LLM_MAX_CONTEXT_LENGTH") or 4096).strip()
-    )
+    LLM_MODEL_ID = str(os.getenv("LLM_MODEL_ID") or "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M").strip()
+    LLM_MAX_CONTEXT_LENGTH = int(str(os.getenv("LLM_MAX_CONTEXT_LENGTH") or 4096).strip())
     LLM_MODEL_RUNNER = str(os.getenv("LLM_MODEL_RUNNER") or "llama_cpp").strip()
     LLM_GPU_TYPE = str(os.getenv("LLM_GPU_TYPE") or "cpu").strip()
     LLM_DRIVER = str(os.getenv("LLM_DRIVER") or "cpu").strip()
-    LLM_LLAMA_CPP_GPU_LAYERS = int(
-        str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS") or 0).strip()
-    )
+    LLM_LLAMA_CPP_GPU_LAYERS = int(str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS") or 0).strip())
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if LLM_LLAMA_CPP_GPU_LAYERS == -1:
         LLM_LLAMA_CPP_GPU_LAYERS = 9999
-    LLM_LLAMA_CPP_CONCURRENCY = int(
-        str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY") or 2).strip()
-    )
+    LLM_LLAMA_CPP_CONCURRENCY = int(str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY") or 2).strip())
     LLM_VLLM_ENFORCE_EAGER = str(os.getenv("LLM_VLLM_ENFORCE_EAGER") or "False").strip()
 
     # HuggingFace configuration
@@ -1044,24 +1010,14 @@ if __name__ == "__main__":
     # Build embedding URL
     if local_embedding_enabled:
         if not EMBEDDING_PORT:
-            raise ValueError(
-                "EMBEDDING_PORT must be set when BASE_EMBEDDING_URL is empty (local embedding service)"
-            )
-        print(
-            "INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service."
-        )
-    embedding_url = (
-        f"http://embedding:{EMBEDDING_PORT}/v1"
-        if local_embedding_enabled
-        else BASE_EMBEDDING_URL
-    )
+            raise ValueError("EMBEDDING_PORT must be set when BASE_EMBEDDING_URL is empty (local embedding service)")
+        print("INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service.")
+    embedding_url = f"http://embedding:{EMBEDDING_PORT}/v1" if local_embedding_enabled else BASE_EMBEDDING_URL
 
     # Build LLM URL
     if local_llm_enabled:
         if not LLM_PORT:
-            raise ValueError(
-                "LLM_PORT must be set when BASE_LLM_URL is empty (local LLM service)"
-            )
+            raise ValueError("LLM_PORT must be set when BASE_LLM_URL is empty (local LLM service)")
         print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service.")
     llm_url = f"http://llm:{LLM_PORT}/v1" if local_llm_enabled else BASE_LLM_URL
 
@@ -1188,7 +1144,8 @@ if __name__ == "__main__":
     # Prepare shell entrypoint script with proper formatting
     shell_entrypoint_str = (
         SHELL_ENTRYPOINT.format(
-            webapp_port=WEBAPP_PORT, uvicorn_workers=UVICORN_WORKERS
+            webapp_port=WEBAPP_PORT,
+            uvicorn_workers=UVICORN_WORKERS,
         )
         .lstrip("\n")
         .rstrip("\n")

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -11,10 +11,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 load_dotenv()
 
-# ============================================================================
-# Compatibility Matrix - Shows valid driver/runner/device combinations
-# ============================================================================
-
+# Compatibility list - Valid driver/runner/device combinations
 COMPATIBILITY_LIST = """
 Drivers:
     - `cpu`
@@ -81,18 +78,11 @@ Drivers:
                     - `intel`
 """.lstrip("\n")
 
-# ============================================================================
-# Docker Compose Template - Main service composition
-# ============================================================================
-
+# Docker compose template - Main service composition
 DOCKER_COMPOSE_TPL = """
 services:
 {services}
 """.lstrip("\n")
-
-# ============================================================================
-# Helper Function - Builds service list with proper spacing
-# ============================================================================
 
 
 def build_services_section(
@@ -144,10 +134,7 @@ def build_services_section(
     return "\n\n".join(services)
 
 
-# ============================================================================
-# GPU Configuration Templates - Driver/device-specific setup
-# ============================================================================
-
+# NVIDIA GPU setup
 NVIDIA_SETUP = """
     deploy:
       resources:
@@ -159,6 +146,7 @@ NVIDIA_SETUP = """
               capabilities: [gpu]
 """.lstrip("\n")
 
+# AMD GPU setup
 AMD_SETUP = """
     devices:
       - /dev/kfd
@@ -168,16 +156,14 @@ AMD_SETUP = """
       - seccomp=unconfined
 """.lstrip("\n")
 
+# Intel GPU setup
 INTEL_SETUP = """
     devices:
       - /dev/dri
     group_add: [video, render]
 """.lstrip("\n")
 
-# ============================================================================
-# Service Configuration Templates
-# ============================================================================
-
+# Postgres service configuration
 POSTGRES_SETUP = """
   postgres:
     container_name: postgres-faith
@@ -196,6 +182,7 @@ POSTGRES_SETUP = """
       retries: {retries}
 """.lstrip("\n")
 
+# Etcd service configuration
 ETCD_SETUP = """
   etcd:
     container_name: etcd-faith
@@ -219,7 +206,7 @@ ETCD_SETUP = """
       retries: {retries}
 """.lstrip("\n")
 
-# SeaweedFS: distributed file storage for Milvus backups
+# SeaweedFS service configuration - distributed file storage for Milvus backups
 SEAWEEDFS_SETUP = """
   seaweedfs-master:
     container_name: seaweedfs-master-faith
@@ -323,7 +310,6 @@ SEAWEEDFS_SETUP = """
 """.lstrip("\n")
 
 
-# Milvus: vector database for semantic search
 def build_milvus_setup(
     local_embedding_enabled,
     start_period,
@@ -387,10 +373,7 @@ def build_milvus_setup(
     return milvus_setup.lstrip("\n")
 
 
-# ============================================================================
-# LLM Runner Configuration Templates - Ollama, llama.cpp, vLLM, SGLang
-# ============================================================================
-
+# Ollama service configuration
 OLLAMA_SETUP = """
   {model_type}:
     container_name: ollama-{model_type}-faith
@@ -432,6 +415,7 @@ LLAMA_CPP_SETUP = """
 {gpu_setup}
 """.lstrip("\n")
 
+# vLLM service configuration
 VLLM_SETUP = """
   {model_type}:
     container_name: vllm-{model_type}-faith
@@ -453,6 +437,7 @@ VLLM_SETUP = """
 {gpu_setup}
 """.lstrip("\n")
 
+# SGLang service configuration
 SGLANG_SETUP = """
   {model_type}:
     container_name: sglang-{model_type}-faith
@@ -475,10 +460,6 @@ SGLANG_SETUP = """
       retries: {retries}
 {gpu_setup}
 """.lstrip("\n")
-
-# ============================================================================
-# Webapp Service Configuration - Built conditionally based on enabled services
-# ============================================================================
 
 
 def build_webapp_setup(
@@ -573,10 +554,7 @@ def build_webapp_setup(
     return webapp_setup.lstrip("\n")
 
 
-# ============================================================================
-# Shell Entrypoint Script - Alternative startup sequence with permissions
-# ============================================================================
-
+# Shell entrypoint script - Alternative startup sequence with permissions
 SHELL_ENTRYPOINT = """
 #!/bin/sh
 
@@ -603,10 +581,6 @@ fi
 log "Starting application server as faith_user"
 exec su faith_user -c "uvicorn fAIth.asgi:application --host 0.0.0.0 --port {webapp_port} --workers {uvicorn_workers}"
 """.lstrip("\n")
-
-# ============================================================================
-# Main Function - Builds runner configuration based on driver/runner/device
-# ============================================================================
 
 
 def build_docker_compose(
@@ -677,10 +651,7 @@ def build_docker_compose(
     else:
         raise ValueError(f"Invalid GPU type: `{gpu_type}`")
 
-    # ========================================================================
-    # CPU Driver - Uses software-based inference
-    # ========================================================================
-
+    # CPU driver - Uses software-based inference
     if driver == "cpu":
         # Warn if user specified GPU type but selected CPU driver
         if gpu_type != "cpu":
@@ -752,10 +723,7 @@ def build_docker_compose(
         else:
             raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
-    # ========================================================================
-    # CUDA Driver - NVIDIA GPU acceleration
-    # ========================================================================
-
+    # CUDA driver - NVIDIA GPU acceleration
     elif driver == "cuda":
         # Validate CUDA only works with NVIDIA GPUs
         if gpu_type != "nvidia":
@@ -824,10 +792,7 @@ def build_docker_compose(
         else:
             raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`")
 
-    # ========================================================================
-    # ROCM Driver - AMD GPU acceleration
-    # ========================================================================
-
+    # ROCM driver - AMD GPU acceleration
     elif driver == "rocm":
         # Validate ROCM only works with AMD GPUs
         if gpu_type != "amd":
@@ -896,10 +861,7 @@ def build_docker_compose(
         else:
             raise ValueError(f"Invalid driver `{driver}` with GPU type `{gpu_type}`. Please check the compatibility list:\n{COMPATIBILITY_LIST}")
 
-    # ========================================================================
-    # VULKAN Driver - Cross-platform GPU acceleration
-    # ========================================================================
-
+    # VULKAN driver - Cross-platform GPU acceleration
     elif driver == "vulkan":
         # Validate VULKAN doesn't support CPU
         if gpu_type == "cpu":
@@ -933,14 +895,10 @@ def build_docker_compose(
     return runner_setup
 
 
-# ============================================================================
-# Main Entry Point - Generates docker-compose.yml and entrypoint script
-# ============================================================================
-
 if __name__ == "__main__":
-    # ========================================================================
-    # Load All Configuration from Environment Variables
-    # ========================================================================
+    """
+    Load all configuration from environment variables and generate docker-compose.yml and entrypoint script.
+    """
 
     # Webapp configuration
     WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT") or 8000).strip())
@@ -996,10 +954,7 @@ if __name__ == "__main__":
     TIMEOUT = "30s"
     RETRIES = 5
 
-    # ========================================================================
-    # Determine Which Services Are Enabled (Based on Port Configuration)
-    # ========================================================================
-
+    # Determine which services are enabled (based on port configuration)
     # Services are only included if their ports are explicitly set
     # If port is empty, user will configure external service (e.g., OpenAI, OpenRouter)
     local_postgres_enabled = not bool(POSTGRES_HOST.strip())
@@ -1021,10 +976,7 @@ if __name__ == "__main__":
         print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service.")
     llm_url = f"http://llm:{LLM_PORT}/v1" if local_llm_enabled else BASE_LLM_URL
 
-    # ========================================================================
-    # Format Service Configuration Blocks
-    # ========================================================================
-
+    # Format service configuration blocks
     if local_postgres_enabled:
         postgres_block = POSTGRES_SETUP.format(
             postgres_user=POSTGRES_USER,
@@ -1124,10 +1076,7 @@ if __name__ == "__main__":
         retries=RETRIES,
     )
 
-    # ========================================================================
     # Assemble Final Docker Compose Configuration
-    # ========================================================================
-
     # Build services section with proper spacing (no gaps for disabled services)
     services_section = build_services_section(
         postgres_setup=postgres_block,
@@ -1151,10 +1100,7 @@ if __name__ == "__main__":
         .rstrip("\n")
     )
 
-    # ========================================================================
-    # Write Generated Files
-    # ========================================================================
-
+    # Write generated files
     with Path("docker-compose.yml").open("w", encoding="utf-8") as f:
         f.write(docker_compose_str)
 

--- a/scripts/build_docker_compose.py
+++ b/scripts/build_docker_compose.py
@@ -276,7 +276,7 @@ SEAWEEDFS_SETUP = """
       AWS_SECRET_ACCESS_KEY: minioadmin
     command: 's3 -filer="seaweedfs-filer:8888" -ip.bind=0.0.0.0 -metricsPort=9327'
     healthcheck:
-      test: ["CMD", "curl", "http://seaweedfs-s3:8333/"]
+      test: ["CMD", "curl", "-f", "http://seaweedfs-s3:8333/"]
       start_period: {start_period}
       interval: {interval}
       timeout: {timeout}
@@ -479,23 +479,13 @@ SGLANG_SETUP = """
 
 def build_webapp_setup(
     postgres_enabled,
-    postgres_host,
-    postgres_port,
-    postgres_user,
-    postgres_password,
-    postgres_database,
     milvus_enabled,
-    milvus_host,
-    milvus_port,
     embedding_enabled,
     embedding_url,
     llm_enabled,
     llm_url,
     webapp_port,
     uvicorn_workers,
-    django_debug,
-    django_secret_key,
-    django_allowed_hosts,
     start_period,
     interval,
     timeout,
@@ -504,26 +494,21 @@ def build_webapp_setup(
     """
     Build webapp configuration with conditional service dependencies.
 
-    If embedding or LLM services are not enabled (ports not set), the webapp
-    will use external services (e.g., OpenAI, OpenRouter) configured via .env.
+    Secrets and app config (Django settings, Postgres/Milvus credentials and
+    endpoints) are intentionally omitted here — they are injected at runtime via
+    env_file: .env, with the app code defaulting to container names when empty.
+    Only embedding and LLM URLs are set explicitly because they are constructed
+    values not directly available in .env (they combine container name + port).
 
     Parameters:
         postgres_enabled (bool): True if using local PostgreSQL service
-        postgres_host: Postgres host
-        postgres_port: Postgres port
-        postgres_user: Postgres user
-        postgres_password: Postgres password
-        postgres_database: Postgres database
         milvus_enabled (bool): True if using local Milvus service
-        milvus_host: Milvus host
-        milvus_port: Milvus port
         embedding_enabled (bool): True if using local embedding service
+        embedding_url: Embedding service URL (constructed from container name + port)
         llm_enabled (bool): True if using local LLM service
+        llm_url: LLM service URL (constructed from container name + port)
         webapp_port: Port to expose webapp on
         uvicorn_workers: Number of uvicorn workers
-        django_debug: Django debug mode
-        django_secret_key: Django secret key
-        django_allowed_hosts: Django allowed hosts
         start_period: Healthcheck start period
         interval: Healthcheck interval
         timeout: Healthcheck timeout
@@ -568,16 +553,6 @@ def build_webapp_setup(
     env_file:
       - .env
     environment:
-      DJANGO_DEBUG: {django_debug}
-      DJANGO_SECRET_KEY: '{django_secret_key}'
-      DJANGO_ALLOWED_HOSTS: '{django_allowed_hosts}'
-      POSTGRES_HOST: {postgres_host}
-      POSTGRES_PORT: {postgres_port}
-      POSTGRES_USER: {postgres_user}
-      POSTGRES_PASSWORD: {postgres_password}
-      POSTGRES_DATABASE: {postgres_database}
-      MILVUS_HOST: {milvus_host}
-      MILVUS_PORT: {milvus_port}
       BASE_EMBEDDING_URL: {embedding_url}
       BASE_LLM_URL: {llm_url}
     command: sh -c "python scripts/docker_milvus_initializer.py && python manage.py migrate && python manage.py collectstatic --noinput --clear && uvicorn fAIth.asgi:application --host 0.0.0.0 --port 8000 --workers {uvicorn_workers}"
@@ -601,7 +576,7 @@ def build_webapp_setup(
 SHELL_ENTRYPOINT = """
 #!/bin/sh
 
-set -euo
+set -euo pipefail
 
 log() {{
     printf '[ENTRYPOINT] %s\n' "$1"
@@ -982,85 +957,72 @@ if __name__ == "__main__":
     # ========================================================================
 
     # Webapp configuration
-    WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT", 8000)).strip())
-    UVICORN_WORKERS = int(str(os.getenv("UVICORN_WORKERS", 1)).strip())
+    WEBAPP_PORT = int(str(os.getenv("WEBAPP_PORT") or 8000).strip())
+    UVICORN_WORKERS = int(str(os.getenv("UVICORN_WORKERS") or 1).strip())
 
     # Postgres configuration
-    POSTGRES_HOST = str(os.getenv("POSTGRES_HOST", "")).strip()
-    POSTGRES_PORT = str(os.getenv("POSTGRES_PORT", "5432")).strip()
-    POSTGRES_USER = str(os.getenv("POSTGRES_USER", "faith_user")).strip()
-    POSTGRES_PASSWORD = str(
-        os.getenv("POSTGRES_PASSWORD", "postgres-secure-password")
-    ).strip()
-    POSTGRES_DATABASE = str(os.getenv("POSTGRES_DATABASE", "faith_db")).strip()
+    POSTGRES_HOST = str(os.getenv("POSTGRES_HOST") or "").strip()
+    POSTGRES_PORT = str(os.getenv("POSTGRES_PORT") or "5432").strip()
+    POSTGRES_USER = str(os.getenv("POSTGRES_USER") or "faith_user").strip()
+    POSTGRES_PASSWORD = str(os.getenv("POSTGRES_PASSWORD") or "").strip()
+    POSTGRES_DATABASE = str(os.getenv("POSTGRES_DATABASE") or "faith_db").strip()
 
     # Milvus configuration
-    MILVUS_HOST = str(os.getenv("MILVUS_HOST", "")).strip()
-    MILVUS_PORT = str(os.getenv("MILVUS_PORT", "19530")).strip()
+    MILVUS_HOST = str(os.getenv("MILVUS_HOST") or "").strip()
+    MILVUS_PORT = str(os.getenv("MILVUS_PORT") or "19530").strip()
 
     # Embedding configuration
-    EMBEDDING_PORT = str(os.getenv("EMBEDDING_PORT", "")).strip()
-    BASE_EMBEDDING_URL = str(os.getenv("BASE_EMBEDDING_URL", "")).strip()
+    EMBEDDING_PORT = str(os.getenv("EMBEDDING_PORT") or "").strip()
+    BASE_EMBEDDING_URL = str(os.getenv("BASE_EMBEDDING_URL") or "").strip()
     EMBEDDING_MODEL_ID = str(
-        os.getenv("EMBEDDING_MODEL_ID", "Qwen/Qwen3-Embedding-0.6B")
+        os.getenv("EMBEDDING_MODEL_ID") or "Qwen/Qwen3-Embedding-0.6B"
     ).strip()
     EMBEDDING_MAX_CONTEXT_LENGTH = int(
-        str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH", 4096)).strip()
+        str(os.getenv("EMBEDDING_MAX_CONTEXT_LENGTH") or 4096).strip()
     )
     EMBEDDING_MODEL_RUNNER = str(
-        os.getenv("EMBEDDING_MODEL_RUNNER", "llama_cpp")
+        os.getenv("EMBEDDING_MODEL_RUNNER") or "llama_cpp"
     ).strip()
-    EMBEDDING_GPU_TYPE = str(os.getenv("EMBEDDING_GPU_TYPE", "cpu")).strip()
-    EMBEDDING_DRIVER = str(os.getenv("EMBEDDING_DRIVER", "cpu")).strip()
+    EMBEDDING_GPU_TYPE = str(os.getenv("EMBEDDING_GPU_TYPE") or "cpu").strip()
+    EMBEDDING_DRIVER = str(os.getenv("EMBEDDING_DRIVER") or "cpu").strip()
     EMBEDDING_VLLM_ENFORCE_EAGER = str(
-        os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER", "False")
+        os.getenv("EMBEDDING_VLLM_ENFORCE_EAGER") or "False"
     ).strip()
     EMBEDDING_LLAMA_CPP_GPU_LAYERS = int(
-        str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS", 0)).strip()
+        str(os.getenv("EMBEDDING_LLAMA_CPP_GPU_LAYERS") or 0).strip()
     )
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if EMBEDDING_LLAMA_CPP_GPU_LAYERS == -1:
         EMBEDDING_LLAMA_CPP_GPU_LAYERS = 9999
     EMBEDDING_LLAMA_CPP_CONCURRENCY = int(
-        str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY", 2)).strip()
+        str(os.getenv("EMBEDDING_LLAMA_CPP_CONCURRENCY") or 2).strip()
     )
 
     # LLM configuration
-    LLM_PORT = str(os.getenv("LLM_PORT", "")).strip()
-    BASE_LLM_URL = str(os.getenv("BASE_LLM_URL", "")).strip()
+    LLM_PORT = str(os.getenv("LLM_PORT") or "").strip()
+    BASE_LLM_URL = str(os.getenv("BASE_LLM_URL") or "").strip()
     LLM_MODEL_ID = str(
-        os.getenv("LLM_MODEL_ID", "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M")
+        os.getenv("LLM_MODEL_ID") or "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_K_M"
     ).strip()
-    LLM_MAX_CONTEXT_LENGTH = int(str(os.getenv("LLM_MAX_CONTEXT_LENGTH", 4096)).strip())
-    LLM_MODEL_RUNNER = str(os.getenv("LLM_MODEL_RUNNER", "llama_cpp")).strip()
-    LLM_GPU_TYPE = str(os.getenv("LLM_GPU_TYPE", "cpu")).strip()
-    LLM_DRIVER = str(os.getenv("LLM_DRIVER", "cpu")).strip()
+    LLM_MAX_CONTEXT_LENGTH = int(
+        str(os.getenv("LLM_MAX_CONTEXT_LENGTH") or 4096).strip()
+    )
+    LLM_MODEL_RUNNER = str(os.getenv("LLM_MODEL_RUNNER") or "llama_cpp").strip()
+    LLM_GPU_TYPE = str(os.getenv("LLM_GPU_TYPE") or "cpu").strip()
+    LLM_DRIVER = str(os.getenv("LLM_DRIVER") or "cpu").strip()
     LLM_LLAMA_CPP_GPU_LAYERS = int(
-        str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS", 0)).strip()
+        str(os.getenv("LLM_LLAMA_CPP_GPU_LAYERS") or 0).strip()
     )
     # Special case: -1 means offload all layers (set to 9999 to effectively offload all)
     if LLM_LLAMA_CPP_GPU_LAYERS == -1:
         LLM_LLAMA_CPP_GPU_LAYERS = 9999
     LLM_LLAMA_CPP_CONCURRENCY = int(
-        str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY", 2)).strip()
+        str(os.getenv("LLM_LLAMA_CPP_CONCURRENCY") or 2).strip()
     )
-    LLM_VLLM_ENFORCE_EAGER = str(os.getenv("LLM_VLLM_ENFORCE_EAGER", "False")).strip()
-
-    # Django configuration
-    DJANGO_DEBUG = str(os.getenv("DJANGO_DEBUG", "False")).strip()
-    DJANGO_SECRET_KEY = str(
-        os.getenv(
-            "DJANGO_SECRET_KEY",
-            "django-insecure-d)+b7f#u@$@q)(ft*qcz1!%^uvy(_ext-^t4d6i$3l$)21__s(",
-        )
-    ).strip()
-    DJANGO_ALLOWED_HOSTS = str(
-        os.getenv("DJANGO_ALLOWED_HOSTS", '["127.0.0.1", "localhost"]')
-    ).strip()
-    print(f"DJANGO_ALLOWED_HOSTS: {DJANGO_ALLOWED_HOSTS}")
+    LLM_VLLM_ENFORCE_EAGER = str(os.getenv("LLM_VLLM_ENFORCE_EAGER") or "False").strip()
 
     # HuggingFace configuration
-    HF_TOKEN = str(os.getenv("HF_TOKEN", "")).strip()
+    HF_TOKEN = str(os.getenv("HF_TOKEN") or "").strip()
 
     # Healthcheck configuration
     START_PERIOD = "3600s"
@@ -1079,28 +1041,12 @@ if __name__ == "__main__":
     local_embedding_enabled = not bool(BASE_EMBEDDING_URL.strip())
     local_llm_enabled = not bool(BASE_LLM_URL.strip())
 
-    # Build Postgres host and port
-    if local_postgres_enabled:
-        print("INFO: POSTGRES_HOST not set. Webapp will use local PostgreSQL service.")
-    postgres_host = "postgres" if local_postgres_enabled else POSTGRES_HOST
-    postgres_port = "5432" if local_postgres_enabled else POSTGRES_PORT
-
-    # If Postgres host is a valid URL, remove the protocol prefix
-    if postgres_host.startswith(("http://", "https://")):
-        postgres_host = postgres_host.replace("http://", "").replace("https://", "")
-
-    # Build Milvus host and port
-    if local_milvus_enabled:
-        print("INFO: MILVUS_HOST not set. Webapp will use local Milvus service.")
-    milvus_host = "milvus" if local_milvus_enabled else MILVUS_HOST
-    milvus_port = "19530" if local_milvus_enabled else MILVUS_PORT
-
-    # If Milvus host is not a valid URL, add http:// prefix
-    if not milvus_host.startswith(("http://", "https://")):
-        milvus_host = f"http://{milvus_host}"
-
     # Build embedding URL
     if local_embedding_enabled:
+        if not EMBEDDING_PORT:
+            raise ValueError(
+                "EMBEDDING_PORT must be set when BASE_EMBEDDING_URL is empty (local embedding service)"
+            )
         print(
             "INFO: BASE_EMBEDDING_URL not set. Webapp will use local embedding service."
         )
@@ -1112,6 +1058,10 @@ if __name__ == "__main__":
 
     # Build LLM URL
     if local_llm_enabled:
+        if not LLM_PORT:
+            raise ValueError(
+                "LLM_PORT must be set when BASE_LLM_URL is empty (local LLM service)"
+            )
         print("INFO: BASE_LLM_URL not set. Webapp will use local LLM service.")
     llm_url = f"http://llm:{LLM_PORT}/v1" if local_llm_enabled else BASE_LLM_URL
 
@@ -1205,23 +1155,13 @@ if __name__ == "__main__":
     # Build webapp with conditional dependencies based on enabled services
     webapp_block = build_webapp_setup(
         postgres_enabled=local_postgres_enabled,
-        postgres_host=postgres_host,
-        postgres_port=postgres_port,
-        postgres_user=POSTGRES_USER,
-        postgres_password=POSTGRES_PASSWORD,
-        postgres_database=POSTGRES_DATABASE,
         milvus_enabled=local_milvus_enabled,
-        milvus_host=milvus_host,
-        milvus_port=milvus_port,
         embedding_enabled=local_embedding_enabled,
         embedding_url=embedding_url,
         llm_enabled=local_llm_enabled,
         llm_url=llm_url,
         webapp_port=WEBAPP_PORT,
         uvicorn_workers=UVICORN_WORKERS,
-        django_debug=DJANGO_DEBUG,
-        django_secret_key=DJANGO_SECRET_KEY,
-        django_allowed_hosts=DJANGO_ALLOWED_HOSTS,
         start_period=START_PERIOD,
         interval=INTERVAL,
         timeout=TIMEOUT,

--- a/webapp_entrypoint.sh
+++ b/webapp_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euo
+set -euo pipefail
 
 log() {
     printf '[ENTRYPOINT] %s


### PR DESCRIPTION
This PR does a few things:
1. Adds security to the local containers by limiting exposed ports to only the webapp so the databases and AI models are not accessible directly from the outside. They are now only accessible from within the Docker network itself.
2. Added security by having generic CHANGE ME passwords so everyone is not on the same password. The loading of the docker compose will fail if the passwords/keys are kept blank or not changed.
3. Adds support for outside Milvus and Postgres databases for security for people in oppressed countries where Christianity is persecuted and it is imperative that user information is not stored locally on-device. NOTE: I have been unable to directly test this, so the changes made are theoretical.