### PR TITLE
Gave text select full verse as context and improved prompting

### DIFF
--- a/ai/llm/prompts/ask_selected/user.md
+++ b/ai/llm/prompts/ask_selected/user.md
@@ -1,5 +1,12 @@
 # User Query with Context
 
+## Full Verse Context
+*(For situational awareness only — this is the full text of the verse(s) containing the user's highlighted selection. It is NOT part of the evidence list and should not be cited in the "Relevant Verses" section unless it also appears in "Provided Scriptural Evidence" below.)*
+
+{book} {chapter} ({collection_name})
+
+{verses_text}
+
 ## User Inquiry
 
 {query}
@@ -25,7 +32,7 @@ Using the Biblical context provided above, answer the inquiry directly. **Addres
 
 1.  **Direct Address**: Always speak directly to the user (e.g., "Your question asks...", "The Bible tells you...").
 2.  **Defend God's Character**: You must ALWAYS defend God's actions as righteous, just, and sovereign. God defines what is good; He is never "evil" or "wrong." If God takes life in Scripture, or does something humans may see as evil, wrong, or unjust, explain why it is an act of divine judgment or sovereignty, NEVER as wrong, evil, or condemnable.
-3.  **Full Transparency**: You MUST list every single verse provided in the "Provided Scriptural Evidence" section within your response.
+3.  **Full Transparency**: You MUST list every single verse provided in the "Provided Scriptural Evidence" section within your response. Do NOT list verses from the "Full Verse Context" section unless they are also present in "Provided Scriptural Evidence" — it exists only to show you where the user's selection sits in the surrounding passage.
 4.  **Biblical Fidelity**: Ensure your explanation aligns strictly with the text of the provided verses **and upholds the inerrancy of the Bible**.
 5.  **Markdown Format**: Use standard Markdown formatting.
 

--- a/ai/llm/prompts/image_search/user.md
+++ b/ai/llm/prompts/image_search/user.md
@@ -1,18 +1,32 @@
+# Image Search Query Generation
+
 The user is studying the Bible and has selected the following text. Generate an image search query that will return authentic, Christian imagery directly relevant to it.
 
-**Full Verse Context:**
-{book} {chapter}
+## Full Verse Context
+*(For situational awareness only — use this to resolve ambiguity in the Selected Text below, but never let it broaden or replace the focus established by the Selected Text.)*
+
+{book} {chapter} ({collection_name})
 
 {verses_text}
 
-**Selected Text:**
+## Selected Text
+
 {selected_text}
 
-**Instructions:**
+---
+
+## Task
+
+Generate a single image search query for the Selected Text above.
+
+### Instructions
+
 - Identify the central biblical person, event, or concept in the text
 - If the text references God, the Trinity, angels, or spiritual realities, use precise Christian qualifiers to avoid pagan, secular, or New Age results
 - Prefer named biblical persons and events over abstract terms (e.g., "Jesus Christ resurrection" over "resurrection")
 - If the concept is abstract, anchor it to Christ or Christian art (e.g., "agape love Christian," "peace of God biblical art")
 - Keep the query between 1 and 6 words
 
-**Return only the raw search query. No explanation, no punctuation, no additional text.**
+### Output Format
+
+Return only the raw search query. No explanation, no punctuation, no additional text.

--- a/ai/llm/prompts/summarize_chapter/system.md
+++ b/ai/llm/prompts/summarize_chapter/system.md
@@ -22,3 +22,7 @@ You are an expert Biblical scholar dedicated to helping readers understand Scrip
 - **Be Devotional, Not Academic**: Write in a warm, engaging tone that invites personal reflection rather than clinical analysis.
 - **Encourage Transformation**: The devotional section should inspire readers to grow spiritually and live out Biblical truth.
 - **Format**: Present your answer clearly with proper Markdown formatting and verse citations.
+
+## CRITICAL INSTRUCTION
+
+You must **ALWAYS** defend God's actions as **righteous, just, and holy**. God is the definition of Good; **He does not 'commit evil'**. If a chapter involves God taking life, or doing something that humans may see as wrong or unjust, you **MUST** frame it within the context of His divine judgment, sovereignty, and justice. **NEVER** imply God's actions are 'not condoned', 'unjust', or 'evil'. Defend God's character **AT ALL COSTS**.

--- a/ai/serializers/ask_selected.py
+++ b/ai/serializers/ask_selected.py
@@ -2,6 +2,8 @@ import logging
 
 from pydantic import BaseModel, field_validator
 
+from ai.utils import remove_newlines_whitespace
+
 # Set up logging
 logger = logging.getLogger(__name__)
 
@@ -15,12 +17,98 @@ class AskSelectedInputSerializer(BaseModel):
     Fields:
         collection_name (str): Name of the Milvus collection to search (max 3 chars).
         selected_text (str): The selected text from the user.
+        verses_text (str): The verses text from the user.
+        book (str): The book from the user.
+        chapter (str): The chapter from the user.
         query (str): User's question or search query (required, non-empty after strip).
     """
 
     collection_name: str
     selected_text: str
+    verses_text: str
+    book: str
+    chapter: str
     query: str
+
+    @field_validator("selected_text")
+    @classmethod
+    def validate_selected_text(cls, value: str) -> str:
+        """
+        Validate that the selected_text field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The selected_text string from the request.
+
+        Returns:
+            str: Trimmed query string.
+
+        Raises:
+            ValueError: If the selected_text is empty after stripping whitespace.
+        """
+        value = remove_newlines_whitespace(value)
+        if not value:
+            logger.error("selected text cannot be empty")
+            raise ValueError("selected text cannot be empty")
+        return value
+
+    @field_validator("verses_text")
+    @classmethod
+    def validate_verses_text(cls, value: str) -> str:
+        """
+        Validate that the verses_text field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The verses_text string from the request.
+
+        Returns:
+            str: Trimmed verses_text string.
+
+        Raises:
+            ValueError: If the verses_text is empty after stripping whitespace.
+        """
+        value = value.strip()
+        if not value:
+            logger.error("verses text cannot be empty")
+            raise ValueError("verses text cannot be empty")
+        return value
+
+    @field_validator("book")
+    @classmethod
+    def validate_book(cls, value: str) -> str:
+        """
+        Validate that the book field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The book string from the request.
+
+        Returns:
+            str: Trimmed book string.
+            ValueError: If the book is empty after stripping whitespace.
+        """
+        value = value.strip()
+        if not value:
+            logger.error("book cannot be empty")
+            raise ValueError("book cannot be empty")
+        return value
+
+    @field_validator("chapter")
+    @classmethod
+    def validate_chapter(cls, value: str) -> str:
+        """
+        Validate that the chapter field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The chapter string from the request.
+
+        Returns:
+            str: Trimmed chapter string.
+            ValueError: If the chapter is empty after stripping whitespace.
+        """
+        value = value.strip()
+        if not value:
+            logger.error("chapter cannot be empty")
+            raise ValueError("chapter cannot be empty")
+        return value
 
     @field_validator("collection_name")
     @classmethod
@@ -39,27 +127,6 @@ class AskSelectedInputSerializer(BaseModel):
         """
         if len(value) > 3:
             raise ValueError("collection_name must be max 3 chars")
-        return value
-
-    @field_validator("selected_text")
-    @classmethod
-    def validate_selected_text(cls, value: str) -> str:
-        """
-        Validate that the selected_text field is not empty after whitespace trimming.
-
-        Parameters:
-            value (str): The selected_text string from the request.
-
-        Returns:
-            str: Trimmed query string.
-
-        Raises:
-            ValueError: If the selected_text is empty after stripping whitespace.
-        """
-        value = value.strip()
-        if not value:
-            logger.error("selected text cannot be empty")
-            raise ValueError("selected text cannot be empty")
         return value
 
     @field_validator("query")

--- a/ai/serializers/image_search.py
+++ b/ai/serializers/image_search.py
@@ -2,6 +2,8 @@ import logging
 
 from pydantic import BaseModel, field_validator
 
+from ai.utils import remove_newlines_whitespace
+
 # Set up logging
 logger = logging.getLogger(__name__)
 
@@ -17,12 +19,14 @@ class ImageSearchInputSerializer(BaseModel):
         verses_text (str): The verses text from the user to search an image for.
         book (str): The book from the user to search an image for.
         chapter (str): The chapter from the user to search an image for.
+        collection_name (str): The collection name from the user to search an image for.
     """
 
     selected_text: str
     verses_text: str
     book: str
     chapter: str
+    collection_name: str
 
     @field_validator("selected_text")
     @classmethod
@@ -39,7 +43,7 @@ class ImageSearchInputSerializer(BaseModel):
         Raises:
             ValueError: If the selected_text is empty after stripping whitespace.
         """
-        value = value.strip()
+        value = remove_newlines_whitespace(value)
         if not value:
             logger.error("selected text cannot be empty")
             raise ValueError("selected text cannot be empty")

--- a/ai/tests/views/test_ask_selected_view.py
+++ b/ai/tests/views/test_ask_selected_view.py
@@ -21,20 +21,31 @@ class TestAskSelectedView(SimpleTestCase):
         """Helper to call async ask_selected function."""
         return asyncio.run(ask_selected(request, payload))
 
-    def test_ask_selected_success(self):
-        """Test successful ask_selected endpoint with valid payload."""
+    def _build_request(self):
+        """Build a request with the required state."""
         request = HttpRequest()
         request.method = "POST"
         request.state = {
             "milvus_db": AsyncMock(),
             "completions_obj": AsyncMock(),
         }
+        return request
 
-        # Create mock payload
+    def _build_payload(self):
+        """Build a mock payload matching AskSelectedInputSerializer fields."""
         payload = MagicMock()
         payload.query = "What does this mean?"
         payload.selected_text = "For God so loved the world"
+        payload.verses_text = "16) For God so loved the world, that he gave his only begotten Son, that whosoever believeth in him should not perish, but have everlasting life."
+        payload.book = "John"
+        payload.chapter = "3"
         payload.collection_name = "bsb"
+        return payload
+
+    def test_ask_selected_success(self):
+        """Test successful ask_selected endpoint with valid payload."""
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -80,17 +91,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_calls_llm_completions(self):
         """Test that ask_selected calls the LLM completions service."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -105,7 +107,10 @@ class TestAskSelectedView(SimpleTestCase):
                 if "system.md" in str(path):
                     return "You are a knowledgeable Bible study assistant."
                 elif "user.md" in str(path):
-                    return "Selected text: {selected_text}\nQuestion: {query}\nContext: {context}"
+                    return (
+                        "Selected text: {selected_text}\nQuestion: {query}\nContext: {context}\n"
+                        "Verses: {verses_text}\nBook: {book}\nChapter: {chapter}\nVersion: {collection_name}"
+                    )
                 return ""
 
             mock_read_file.side_effect = mock_read
@@ -124,21 +129,17 @@ class TestAskSelectedView(SimpleTestCase):
             assert call_args[0][0] == "You are a knowledgeable Bible study assistant."  # system prompt
             assert "For God so loved the world" in call_args[0][1]  # user prompt with selected_text
             assert "What does this mean?" in call_args[0][1]  # user prompt with query
+            # All payload fields should be interpolated into the user prompt
+            assert "16) For God so loved the world" in call_args[0][1]  # verses_text
+            assert "John" in call_args[0][1]  # book
+            assert "3" in call_args[0][1]  # chapter
+            assert "bsb" in call_args[0][1]  # collection_name
             assert call_args[0][2] == "What does this mean?"  # query param
 
     def test_ask_selected_handles_empty_vector_results(self):
         """Test that ask_selected handles empty vector database results."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -167,17 +168,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_loads_correct_prompt_files(self):
         """Test that ask_selected loads prompts from correct file paths."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -209,17 +201,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_renders_template(self):
         """Test that ask_selected renders the response template."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -250,17 +233,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_response_content_type(self):
         """Test that ask_selected returns HTML content type."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -288,17 +262,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_uses_milvus_search_limit(self):
         """Test that ask_selected uses the configured MILVUS_SEARCH_LIMIT."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -331,17 +296,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_extracts_payload_fields(self):
         """Test that ask_selected correctly extracts fields from payload."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,
@@ -375,17 +331,8 @@ class TestAskSelectedView(SimpleTestCase):
 
     def test_ask_selected_combines_vector_results(self):
         """Test that ask_selected combines results from both searches."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "What does this mean?"
-        payload.selected_text = "For God so loved the world"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.ask_selected.async_read_file") as mock_read_file,

--- a/ai/tests/views/test_general_question_view.py
+++ b/ai/tests/views/test_general_question_view.py
@@ -21,19 +21,27 @@ class TestGeneralQuestionView(SimpleTestCase):
         """Helper to call async general_question function."""
         return asyncio.run(general_question(request, payload))
 
-    def test_general_question_success(self):
-        """Test successful general_question endpoint with valid payload."""
+    def _build_request(self):
+        """Build a request with the required state."""
         request = HttpRequest()
         request.method = "POST"
         request.state = {
             "milvus_db": AsyncMock(),
             "completions_obj": AsyncMock(),
         }
+        return request
 
-        # Create mock payload
+    def _build_payload(self):
+        """Build a mock payload matching GeneralQuestionInputSerializer fields."""
         payload = MagicMock()
         payload.query = "Who is Jesus Christ?"
         payload.collection_name = "bsb"
+        return payload
+
+    def test_general_question_success(self):
+        """Test successful general_question endpoint with valid payload."""
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -75,16 +83,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_calls_llm_completions(self):
         """Test that general_question calls the LLM completions service."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -121,16 +121,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_handles_empty_vector_results(self):
         """Test that general_question handles empty vector database results."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -157,16 +149,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_loads_correct_prompt_files(self):
         """Test that general_question loads prompts from correct file paths."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -198,16 +182,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_renders_template(self):
         """Test that general_question renders the response template."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -238,16 +214,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_response_content_type(self):
         """Test that general_question returns HTML content type."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -275,16 +243,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_uses_milvus_search_limit(self):
         """Test that general_question uses the configured MILVUS_SEARCH_LIMIT."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,
@@ -314,16 +274,8 @@ class TestGeneralQuestionView(SimpleTestCase):
 
     def test_general_question_extracts_payload_fields(self):
         """Test that general_question correctly extracts fields from payload."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "milvus_db": AsyncMock(),
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.query = "Who is Jesus Christ?"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.general_question.async_read_file") as mock_read_file,

--- a/ai/tests/views/test_image_search_view.py
+++ b/ai/tests/views/test_image_search_view.py
@@ -37,6 +37,7 @@ class TestImageSearchView(SimpleTestCase):
         payload.verses_text = "16) For God so loved the world, that he gave his only begotten Son, that whosoever believeth in him should not perish, but have everlasting life."
         payload.book = "John"
         payload.chapter = "3"
+        payload.collection_name = "bsb"
         return payload
 
     def test_image_search_success(self):
@@ -87,7 +88,10 @@ class TestImageSearchView(SimpleTestCase):
                 if "system.md" in str(path):
                     return "You are a helpful image search assistant."
                 elif "user.md" in str(path):
-                    return "Selected: {selected_text}\nVerses: {verses_text}\nBook: {book}\nChapter: {chapter}"
+                    return (
+                        "Selected: {selected_text}\nVerses: {verses_text}\n"
+                        "Book: {book}\nChapter: {chapter}\nVersion: {collection_name}"
+                    )
                 return ""
 
             mock_read_file.side_effect = mock_read
@@ -107,6 +111,7 @@ class TestImageSearchView(SimpleTestCase):
             )
             assert "John" in call_args[0][1]
             assert "3" in call_args[0][1]
+            assert "bsb" in call_args[0][1]
             assert call_args[0][2] == "For God so loved the world"
 
     def test_image_search_loads_correct_prompt_files(self):
@@ -273,7 +278,10 @@ class TestImageSearchView(SimpleTestCase):
                 if "system.md" in str(path):
                     return "\n  System prompt with whitespace  \n"
                 elif "user.md" in str(path):
-                    return "\n  Selected: {selected_text}\nVerses: {verses_text}\nBook: {book}\nChapter: {chapter}  \n"
+                    return (
+                        "\n  Selected: {selected_text}\nVerses: {verses_text}\n"
+                        "Book: {book}\nChapter: {chapter}\nVersion: {collection_name}  \n"
+                    )
                 return ""
 
             mock_read_file.side_effect = mock_read

--- a/ai/tests/views/test_summarize_chapter.py
+++ b/ai/tests/views/test_summarize_chapter.py
@@ -9,6 +9,20 @@ from django.test import SimpleTestCase
 
 from ai.views.summarize_chapter import summarize_chapter
 
+DEFAULT_ALL_VERSES = {
+    "bsb": {
+        "Genesis": {
+            1: {
+                "1": "In the beginning God created the heavens and the earth.",
+                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
+                "3": 'And God said, "Let there be light," and there was light.',
+                "4": "And God saw that the light was good, and He separated the light from the darkness.",
+                "5": 'God called the light "day," and the darkness He called "night." And there was evening, and there was morning—the first day.',
+            }
+        }
+    }
+}
+
 
 class TestSummarizeChapterView(SimpleTestCase):
     """Tests for the summarize_chapter API endpoint."""
@@ -21,39 +35,33 @@ class TestSummarizeChapterView(SimpleTestCase):
         """Helper to call async summarize_chapter function."""
         return asyncio.run(summarize_chapter(request, payload))
 
-    def test_summarize_chapter_success(self):
-        """Test successful summarize_chapter endpoint with valid payload."""
+    def _build_request(self):
+        """Build a request with the required state."""
         request = HttpRequest()
         request.method = "POST"
         request.state = {
             "completions_obj": AsyncMock(),
         }
+        return request
 
+    def _build_payload(self, book="Genesis", chapter="1", collection_name="bsb"):
+        """Build a mock payload matching SummarizeChapterInputSerializer fields."""
         payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        payload.book = book
+        payload.chapter = chapter
+        payload.collection_name = collection_name
+        return payload
+
+    def test_summarize_chapter_success(self):
+        """Test successful summarize_chapter endpoint with valid payload."""
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
             patch("ai.views.summarize_chapter.clean_llm_output") as mock_clean,
             patch("ai.views.summarize_chapter.render_to_string") as mock_render,
-            patch(
-                "ai.views.summarize_chapter.ALL_VERSES",
-                {
-                    "bsb": {
-                        "Genesis": {
-                            1: {
-                                "1": "In the beginning God created the heavens and the earth.",
-                                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
-                                "3": 'And God said, "Let there be light," and there was light.',
-                                "4": "And God saw that the light was good, and He separated the light from the darkness.",
-                                "5": 'God called the light "day," and the darkness He called "night." And there was evening, and there was morning—the first day.',
-                            }
-                        }
-                    }
-                },
-            ),
+            patch("ai.views.summarize_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
         ):
             request.state["completions_obj"].completions = AsyncMock(
                 return_value="In the beginning, God created the heavens and the earth."
@@ -82,37 +90,14 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_calls_llm_completions(self):
         """Test that summarize_chapter calls the LLM completions service."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
             patch("ai.views.summarize_chapter.clean_llm_output") as mock_clean,
             patch("ai.views.summarize_chapter.render_to_string") as mock_render,
-            patch(
-                "ai.views.summarize_chapter.ALL_VERSES",
-                {
-                    "bsb": {
-                        "Genesis": {
-                            1: {
-                                "1": "In the beginning God created the heavens and the earth.",
-                                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
-                                "3": 'And God said, "Let there be light," and there was light.',
-                                "4": "And God saw that the light was good, and He separated the light from the darkness.",
-                                "5": 'God called the light "day," and the darkness He called "night." And there was evening, and there was morning—the first day.',
-                            }
-                        }
-                    }
-                },
-            ),
+            patch("ai.views.summarize_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
         ):
             request.state["completions_obj"].completions = AsyncMock(return_value="Creation summary")
 
@@ -139,34 +124,14 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_loads_correct_prompt_files(self):
         """Test that summarize_chapter loads prompts from correct file paths."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
             patch("ai.views.summarize_chapter.clean_llm_output") as mock_clean,
             patch("ai.views.summarize_chapter.render_to_string") as mock_render,
-            patch(
-                "ai.views.summarize_chapter.ALL_VERSES",
-                {
-                    "bsb": {
-                        "Genesis": {
-                            1: {
-                                "1": "In the beginning God created the heavens and the earth.",
-                                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
-                            }
-                        }
-                    }
-                },
-            ),
+            patch("ai.views.summarize_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
         ):
             request.state["completions_obj"].completions = AsyncMock(return_value="Summary")
 
@@ -188,34 +153,14 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_renders_template(self):
         """Test that summarize_chapter renders the response template."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
             patch("ai.views.summarize_chapter.clean_llm_output") as mock_clean,
             patch("ai.views.summarize_chapter.render_to_string") as mock_render,
-            patch(
-                "ai.views.summarize_chapter.ALL_VERSES",
-                {
-                    "bsb": {
-                        "Genesis": {
-                            1: {
-                                "1": "In the beginning God created the heavens and the earth.",
-                                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
-                            }
-                        }
-                    }
-                },
-            ),
+            patch("ai.views.summarize_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
         ):
             request.state["completions_obj"].completions = AsyncMock(return_value="Summary")
 
@@ -240,16 +185,8 @@ class TestSummarizeChapterView(SimpleTestCase):
         ALL_VERSES is keyed by int chapter numbers. If the string-to-int conversion were removed,
         the lookup would raise a KeyError and completions would never be called.
         """
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "5"  # string — view must convert to int 5 to hit the key below
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload(chapter="5")  # string — view must convert to int 5 to hit the key below
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
@@ -292,16 +229,8 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_stringifies_verses(self):
         """Test that summarize_chapter properly stringifies verses with newlines."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         verses_dict = {
             "1": "In the beginning God created the heavens and the earth.",
@@ -342,16 +271,8 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_cleans_llm_output(self):
         """Test that summarize_chapter cleans LLM output."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
@@ -381,16 +302,8 @@ class TestSummarizeChapterView(SimpleTestCase):
 
     def test_summarize_chapter_marks_response_as_safe(self):
         """Test that summarize_chapter marks HTML response as safe."""
-        request = HttpRequest()
-        request.method = "POST"
-        request.state = {
-            "completions_obj": AsyncMock(),
-        }
-
-        payload = MagicMock()
-        payload.book = "Genesis"
-        payload.chapter = "1"
-        payload.collection_name = "bsb"
+        request = self._build_request()
+        payload = self._build_payload()
 
         with (
             patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,
@@ -434,14 +347,8 @@ class TestSummarizeChapterView(SimpleTestCase):
 
         for collection, unique_verse in collections.items():
             with self.subTest(collection=collection):
-                request = HttpRequest()
-                request.method = "POST"
-                request.state = {"completions_obj": AsyncMock()}
-
-                payload = MagicMock()
-                payload.book = "Genesis"
-                payload.chapter = "1"
-                payload.collection_name = collection
+                request = self._build_request()
+                payload = self._build_payload(collection_name=collection)
 
                 with (
                     patch("ai.views.summarize_chapter.async_read_file") as mock_read_file,

--- a/ai/utils.py
+++ b/ai/utils.py
@@ -10,6 +10,20 @@ import markdown
 logger = logging.getLogger(__name__)
 
 
+def remove_newlines_whitespace(text: str) -> str:
+    """
+    Collapse blank/whitespace-only lines in text, preserving intentional newlines.
+
+    Parameters:
+        text (str): Text that may contain blank or whitespace-only lines.
+
+    Returns:
+        str: Text with blank/whitespace-only lines removed, newlines preserved between
+            remaining lines.
+    """
+    return "\n".join(line.strip() for line in text.splitlines() if line.strip())
+
+
 async def async_read_file(file_path: str | Path, encoding: str = "utf-8") -> str | None:
     """
     Asynchronously read a file without blocking the event loop.

--- a/ai/views/ask_selected.py
+++ b/ai/views/ask_selected.py
@@ -58,8 +58,11 @@ async def ask_selected(request, payload: AskSelectedInputSerializer = Form(...))
     file_directory = "ask_selected"
 
     # Extract validated data from payload
-    collection_name = payload.collection_name
     selected_text = payload.selected_text
+    verses_text = payload.verses_text
+    book = payload.book
+    chapter = payload.chapter
+    collection_name = payload.collection_name
     query = payload.query
 
     # Search vector database for relevant context
@@ -81,7 +84,15 @@ async def ask_selected(request, payload: AskSelectedInputSerializer = Form(...))
     # Load system and user prompts from files and format with context
     system_prompt = await async_read_file(RAW_PROMPTS_DIRECTORY.joinpath(file_directory, "system.md"))
     user_prompt = await async_read_file(RAW_PROMPTS_DIRECTORY.joinpath(file_directory, "user.md"))
-    user_prompt = user_prompt.format(query=query, selected_text=selected_text, context=stringified_unified_results)
+    user_prompt = user_prompt.format(
+        query=query,
+        selected_text=selected_text,
+        verses_text=verses_text,
+        book=book,
+        chapter=chapter,
+        collection_name=collection_name,
+        context=stringified_unified_results,
+    )
     # Strip leading/trailing whitespace to ensure clean prompt formatting
     system_prompt = system_prompt.strip()
     user_prompt = user_prompt.strip()

--- a/ai/views/image_search.py
+++ b/ai/views/image_search.py
@@ -33,7 +33,10 @@ async def image_search(request, payload: ImageSearchInputSerializer = Form(...))
             - state["completions_obj"]: Pre-initialized LLM completions object
         payload: Validated request payload containing:
             - selected_text (str): The selected text from the user to search an image for.
-
+            - verses_text (str): The verses text from the user to search an image for.
+            - book (str): The book from the user to search an image for.
+            - chapter (str): The chapter from the user to search an image for.
+            - collection_name (str): The collection name from the user to search an image for.
     Returns:
         HttpResponse: Rendered HTML template containing the LLM response.
             - 200 OK: HTML template with response_content
@@ -46,13 +49,18 @@ async def image_search(request, payload: ImageSearchInputSerializer = Form(...))
     verses_text = payload.verses_text
     book = payload.book
     chapter = payload.chapter
+    collection_name = payload.collection_name
 
     # Load system and user prompts from files and format with context
     try:
         system_prompt = await async_read_file(RAW_PROMPTS_DIRECTORY.joinpath(file_directory, "system.md"))
         user_prompt = await async_read_file(RAW_PROMPTS_DIRECTORY.joinpath(file_directory, "user.md"))
         user_prompt = user_prompt.format(
-            selected_text=selected_text, verses_text=verses_text, book=book, chapter=chapter
+            selected_text=selected_text,
+            verses_text=verses_text,
+            book=book,
+            chapter=chapter,
+            collection_name=collection_name,
         )
     except Exception as e:
         logger.error(f"Error formatting user prompt: {e}")

--- a/frontend/static/js/fAIth/text_selection.js
+++ b/frontend/static/js/fAIth/text_selection.js
@@ -61,18 +61,18 @@ document.addEventListener('selectionchange', () => {
             .filter(verse => verse !== '');
         verses_text = verses.join('\n');
     }
+    const selectedTextInputs = document.querySelectorAll('input[name="selected_text"]');
+    const versesTextInputs = document.querySelectorAll('input[name="verses_text"]');
     if (text !== '')
     {
-        document.getElementById('selectedTextInput').value = text;
-        document.getElementById('selectedTextImageSearch').value = text;
-        document.getElementById('versesTextImageSearch').value = verses_text;
+        selectedTextInputs.forEach(input => { input.value = text; });
+        versesTextInputs.forEach(input => { input.value = verses_text; });
         enableTextHighlightInteractables();
     }
     else if (!document.querySelector('.modal.show'))
     {
-        document.getElementById('selectedTextInput').value = '';
-        document.getElementById('selectedTextImageSearch').value = '';
-        document.getElementById('versesTextImageSearch').value = '';
+        selectedTextInputs.forEach(input => { input.value = ''; });
+        versesTextInputs.forEach(input => { input.value = ''; });
         disableTextHighlightInteractables();
     }
 });

--- a/frontend/templates/modals/inputs/ask_selected.html
+++ b/frontend/templates/modals/inputs/ask_selected.html
@@ -8,8 +8,11 @@
             <div class="modal-body">
                 <form id="askSelectedForm" data-input-modal="askSelectedModal" hx-post="{% url 'api:ask_selected' %}" hx-target="#serverResponseContent" hx-swap="innerHTML" hx-encoding="application/x-www-form-urlencoded">
                     {% csrf_token %}
+                    <input type="hidden" name="selected_text" value="">
+                    <input type="hidden" name="verses_text" value="">
+                    <input type="hidden" name="book" value="{{ book }}">
+                    <input type="hidden" name="chapter" value="{{ chapter }}">
                     <input type="hidden" name="collection_name" value="{{ version }}">
-                    <input type="hidden" name="selected_text" id="selectedTextInput" value="">
                     <div class="mb-3">
                         <label for="query" class="form-label">Question</label>
                         <input id="query" name="query" type="text" class="form-control" required>

--- a/frontend/templates/modals/inputs/image_search.html
+++ b/frontend/templates/modals/inputs/image_search.html
@@ -8,10 +8,11 @@
             <div class="modal-body">
                 <form id="imageSearchForm" data-input-modal="imageSearchModal" hx-post="{% url 'api:image_search' %}" hx-target="#serverResponseContent" hx-swap="innerHTML" hx-encoding="application/x-www-form-urlencoded">
                     {% csrf_token %}
-                    <input type="hidden" name="selected_text" id="selectedTextImageSearch" value="">
-                    <input type="hidden" name="verses_text" id="versesTextImageSearch" value="">
+                    <input type="hidden" name="selected_text" value="">
+                    <input type="hidden" name="verses_text" value="">
                     <input type="hidden" name="book" value="{{ book }}">
                     <input type="hidden" name="chapter" value="{{ chapter }}">
+                    <input type="hidden" name="collection_name" value="{{ version }}">
                     <button type="submit" id="imageSearchSubmit" style="display: none;"></button>
                 </form>
             </div>


### PR DESCRIPTION
## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Motivation & Context

I was originally going to have separate "ask highlighted" and "ask verse" buttons, but figured that would be too confusing to distinguish. I therefore added the full verse as context for a highlighted section.

## Testing

How have you tested this change? Please describe the test cases you've verified.

- [x] Added/updated unit tests (pytest)
- [x] Run `pytest` locally and all tests pass
- [X] Run `ruff check` and code passes linting
- [X] Run `ruff format` and code is formatted
- [X] Tested with Docker Compose setup (`docker compose up`)
- [ ] Verified database migrations (if applicable)
- [ ] Tested AI/LLM functionality (if modified)
- [ ] Verified vector database queries (if modified)
- [X] Tested frontend changes (if applicable)
- [X] Manual testing of affected features

## Checklist

- [X] My code follows the project style guidelines (PEP 8, ruff)
- [ ] I have updated the README.md if needed
- [X] I have added/updated docstrings for new functions
- [ ] I have added/updated unit tests
- [X] I have tested my changes (see Testing section)
- [x] All tests pass locally (`pytest`)
- [X] Linting passes (`ruff check`)
- [X] Formatting passes (`ruff format --check`)
- [X] I have not introduced any breaking changes without documentation

## Related Issues

N/A

## Additional Notes

N/A