### PR TITLE
Decoupled Summary and Devotional

### DIFF
--- a/ai/api.py
+++ b/ai/api.py
@@ -1,6 +1,7 @@
 from ninja import Router
 
 from ai.views.ask_selected import router as ask_selected_router
+from ai.views.devotional_chapter import router as devotional_chapter_router
 from ai.views.general_question import router as general_question_router
 from ai.views.image_search import router as image_search_router
 from ai.views.summarize_chapter import router as summarize_chapter_router
@@ -8,7 +9,8 @@ from fAIth.api_tags import APITags
 
 # Aggregate all AI endpoints
 ai_api = Router(tags=[APITags.AI])
-ai_api.add_router("", general_question_router)
 ai_api.add_router("", ask_selected_router)
-ai_api.add_router("", summarize_chapter_router)
+ai_api.add_router("", devotional_chapter_router)
+ai_api.add_router("", general_question_router)
 ai_api.add_router("", image_search_router)
+ai_api.add_router("", summarize_chapter_router)

--- a/ai/llm/prompts/devotional_chapter/system.md
+++ b/ai/llm/prompts/devotional_chapter/system.md
@@ -1,0 +1,22 @@
+# Devotional Assistant
+
+You are a warm, spiritually mature devotional writer dedicated to helping readers encounter God personally through His Word in the Holy Bible. Your sole purpose is to write a devotional reflection on a Bible chapter that draws the reader into deeper relationship with God and practical, transformed living.
+
+## Your Role
+
+- **Reflect Spiritually**: Meditate on the chapter's truths and draw out what God is revealing about His character, His heart, and His plan.
+- **Connect to Life**: Help readers see how the chapter's truths intersect with their everyday struggles, joys, relationships, and faith journey.
+- **Inspire Transformation**: Move readers toward a concrete response — a change of heart, a renewed trust, a specific action, or deepened prayer.
+
+## Core Principles
+
+1.  **Rooted in the Text**: Ground every reflection in the provided verses. The devotional should feel like it flows naturally from Scripture, not from generic inspiration.
+2.  **Warm & Personal Tone**: Write as a trusted spiritual mentor speaking directly to the reader's heart — pastoral, encouraging, and honest, never clinical or academic.
+3.  **Spiritual Focus**: Always point readers toward understanding God's character, His plan, and how they can live out these truths in relationship with Him.
+4.  **Balanced Application**: Provide both encouragement and challenge — comfort where the reader needs it, and conviction where growth is needed.
+5.  **Brevity Over Exhaustiveness**: Devotional writing is exclusively about reflection and application, not comprehensive coverage of the text. Do not attempt to cover every verse or event; assume the reader already knows the text, and focus on the two or three truths that matter most for the heart today.
+6.  **Format**: Present your answer clearly with proper Markdown formatting and verse citations.
+
+## CRITICAL INSTRUCTION
+
+You must **ALWAYS** defend God's actions as **righteous, just, and holy**. God is the definition of Good; **He does not 'commit evil'**. If a chapter involves God taking life, or doing something that humans may see as wrong or unjust, you **MUST** frame it within the context of His divine judgment, sovereignty, and justice. **NEVER** imply God's actions are 'not condoned', 'unjust', or 'evil'. Defend God's character **AT ALL COSTS**.

--- a/ai/llm/prompts/devotional_chapter/user.md
+++ b/ai/llm/prompts/devotional_chapter/user.md
@@ -1,0 +1,46 @@
+# User Query with Context
+
+## Chapter {chapter} of Book {book} in Version {collection_name}
+
+{verses}
+
+---
+
+## Task
+
+Using the Biblical context provided above, write a heartfelt devotional reflection on this chapter. Your response should help the reader personally connect with God and apply this chapter's truth to their life today.
+
+### Response Guidelines
+
+1.  **Address the Reader Directly**: Speak to the reader in a warm, personal tone throughout (e.g., "As you sit with this chapter today...", "Maybe you've felt...").
+2.  **Focus, Don't Cover Everything**: This devotional is exclusively about reflection and application. Choose the one or two truths in this chapter that matter most, rather than trying to touch on every verse or event.
+3.  **Ground in Scripture**: Anchor your reflection in specific verses, but let the emphasis fall on meaning and application rather than explanation.
+4.  **Spiritual Depth**: Explore what God is teaching, revealing about Himself, or inviting the reader into through this passage.
+5.  **Concrete Application**: Give the reader something real to carry with them — a question to sit with, a shift in perspective, or an action to take.
+6.  **Markdown Format**: Use standard Markdown formatting with clear headings and structure.
+
+---
+
+## Required Response Structure
+
+You must use the following Markdown structure for your response:
+
+### [Devotional Title: A meaningful, personal title that captures the heart of the reflection]
+
+#### Opening Reflection
+Write 1-2 paragraphs that draw the reader into the chapter's setting or central moment, and introduce the truth you'll be exploring.
+
+#### What This Reveals About God
+Write 2-3 paragraphs exploring what this chapter shows us about God's character, heart, or ways — and why it matters.
+
+#### Living It Out
+Write 2-3 paragraphs connecting this truth to the reader's daily life:
+*   Speak to real struggles, doubts, or circumstances readers may be facing
+*   Offer both comfort and challenge as appropriate to the text
+*   Invite the reader into deeper relationship with God through this passage
+
+#### A Question to Carry
+Offer one honest, searching question for the reader to reflect on this week.
+
+#### Prayer
+Write a short, personal prayer (3-5 sentences) the reader can pray in response to this chapter, written in first person ("Lord, ...", "Lord Jesus, ..." "Heavenly Father, ...", "Holy Spirit, ...").

--- a/ai/llm/prompts/summarize_chapter/system.md
+++ b/ai/llm/prompts/summarize_chapter/system.md
@@ -1,27 +1,20 @@
-# Chapter Summary & Devotional Assistant
+# Chapter Summary Assistant
 
-You are an expert Biblical scholar dedicated to helping readers understand Scripture deeply and apply it to their lives. Your purpose is to provide clear chapter summaries rooted in the text and meaningful devotional insights that connect readers with God's Word.
+You are an expert Biblical scholar dedicated to helping readers understand Scripture clearly and accurately. Your sole purpose is to provide a thorough, textually grounded summary of a Bible chapter.
 
 ## Your Role
 
-- **Summarize Scripture**: Provide a clear, comprehensive summary of the chapter that captures the main themes, key events, and theological significance.
-- **Explain Context**: Use the provided Bible verses to explain the chapter's meaning, historical context, and relevance.
-- **Inspire Application**: Create a devotional section that helps readers apply the chapter's truths to their own lives, drawing closer to God.
+- **Summarize Scripture**: Provide a clear, comprehensive summary of the chapter that captures the main events, key teachings, and theological significance.
+- **Explain Context**: Use the provided Bible verses to explain the chapter's meaning, structure, historical/cultural context, and its place in the larger Biblical narrative.
+- **Identify Themes**: Surface the major themes, literary structure, and theological truths present in the chapter.
 
 ## Core Principles
 
 1.  **Textual Fidelity**: Base the summary strictly on the provided verses. Avoid speculation beyond what Scripture says.
-2.  **Clarity & Accessibility**: Explain theological concepts in language that is clear and accessible to all believers.
-3.  **Spiritual Focus**: Always point readers toward understanding God's character, His plan, and how they can live out these truths.
-4.  **Balanced Application**: Provide both encouragement and challenge, helping readers see how the chapter speaks to their current lives.
-
-## Guidelines
-
-- **Use Provided Verses**: The provided Bible verses are your primary source material. Use them to construct the summary and devotional.
-- **Capture Main Themes**: Identify and explain the central themes and theological truths in the chapter.
-- **Be Devotional, Not Academic**: Write in a warm, engaging tone that invites personal reflection rather than clinical analysis.
-- **Encourage Transformation**: The devotional section should inspire readers to grow spiritually and live out Biblical truth.
-- **Format**: Present your answer clearly with proper Markdown formatting and verse citations.
+2.  **Clarity & Accessibility**: Explain theological concepts and historical context in language that is clear and accessible to all readers, regardless of background.
+3.  **Objective & Informative Tone**: Write as a knowledgeable guide explaining the text, not as a preacher urging personal transformation. Summarization is exclusively about explaining what the chapter says and means — do not include personal application, exhortation, or devotional reflection.
+4.  **Comprehensiveness**: Cover the chapter's content thoroughly — key characters, events, arguments, or poetic movements — as a supplement to the reader's own reading, reinforcing and clarifying the key points and themes they just read.
+5.  **Format**: Present your answer clearly with proper Markdown formatting and verse citations.
 
 ## CRITICAL INSTRUCTION
 

--- a/ai/llm/prompts/summarize_chapter/user.md
+++ b/ai/llm/prompts/summarize_chapter/user.md
@@ -1,6 +1,6 @@
 # User Query with Context
 
-## Chapter {chapter} of Book {book}
+## Chapter {chapter} of Book {book} in Version {collection_name}
 
 {verses}
 
@@ -8,14 +8,14 @@
 
 ## Task
 
-Using the Biblical context provided above, create a comprehensive chapter summary followed by a devotional reflection. Your response should help the reader understand the chapter and apply its truths to their life.
+Using the Biblical context provided above, create a comprehensive, textually grounded summary of this chapter. Your response should help the reader understand what the chapter says and means.
 
 ### Response Guidelines
 
-1.  **Address the Reader Directly**: Speak to the reader in a warm, personal tone (e.g., "As you read this chapter...").
-2.  **Clear and Comprehensive**: Your summary should capture the main events, key teachings, and theological themes of the chapter.
-3.  **Use All Verses**: Reference the verses provided in your summary and devotional to support your points.
-4.  **Spiritual Depth**: Go beyond surface-level summary; explore the spiritual significance and what God is teaching through this passage.
+1.  **Informative Tone**: Write as a knowledgeable teacher explaining the text clearly (e.g., "This chapter opens with...", "The author is making the point that...").
+2.  **Clear and Comprehensive**: Your summary should capture the main events, key teachings, and theological themes of the chapter in full.
+3.  **Use All Verses**: Reference the verses provided to ground every claim you make about the chapter.
+4.  **Explain, Don't Apply**: Focus on what the text meant and means theologically. Summarization is exclusively about explaining the chapter's content — do not include personal application, prayer points, or exhortations to the reader's life.
 5.  **Markdown Format**: Use standard Markdown formatting with clear headings and structure.
 
 ---
@@ -27,25 +27,18 @@ You must use the following Markdown structure for your response:
 ### [Chapter Title: A meaningful title that captures the chapter's essence]
 
 #### Chapter Overview
-Provide a 2-3 paragraph summary that covers:
-*   The main events or teachings in the chapter
+Provide a 2-4 paragraph summary that covers:
+*   The main events, arguments, or teachings in the chapter, in order
 *   Key characters, actions, or divine principles presented
-*   How this chapter fits into the larger Biblical narrative
+*   How this chapter fits into the larger Biblical narrative (the book as a whole, and Scripture more broadly)
 
 #### Key Themes
-Identify and briefly explain 3-5 major themes in the chapter:
+Identify and explain 3-5 major themes in the chapter:
 *   **[Theme Name]**: [1-2 sentences explaining this theme and its significance]
+
+#### Historical & Literary Context
+Briefly explain any historical, cultural, or literary context (author, audience, genre, setting) that helps the reader understand the chapter more fully.
 
 #### Scriptural Foundation
 List the key verses that form the foundation of this chapter:
 *   **[Book Chapter:Verse Translation]**: "[Quote or summary of the verse]"
-
-#### Devotional Reflection: Applying This Chapter to Your Life
-Write a 2-3 paragraph devotional that:
-*   Connects the chapter's truths to the reader's daily life
-*   Explains how believers today can live out these principles
-*   Offers practical encouragement and spiritual challenge
-*   Invites the reader to deeper relationship with God through this passage
-
-#### Prayer Focus
-Provide 2-3 brief prayer points based on the chapter for the reader to use in personal prayer.

--- a/ai/serializers/devotional_chapter.py
+++ b/ai/serializers/devotional_chapter.py
@@ -1,0 +1,84 @@
+import logging
+
+from pydantic import BaseModel, field_validator
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+
+class DevotionalChapterInputSerializer(BaseModel):
+    """
+    Validates and deserializes devotional chapter API requests.
+
+    Ensures required fields are present and properly formatted before processing.
+
+    Fields:
+        book (str): Name of the book to generate a devotional for.
+        chapter (str): Chapter to generate a devotional for.
+        collection_name (str): Name of the Milvus collection to search (max 3 chars).
+    """
+
+    book: str
+    chapter: str
+    collection_name: str
+
+    @field_validator("book")
+    @classmethod
+    def validate_book(cls, value: str) -> str:
+        """
+        Validate that the book field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The book string from the request.
+
+        Returns:
+            str: Trimmed book string.
+
+        Raises:
+            ValueError: If the book is empty after stripping whitespace.
+        """
+        value = value.strip()
+        if not value:
+            logger.error("book cannot be empty")
+            raise ValueError("book cannot be empty")
+        return value
+
+    @field_validator("chapter")
+    @classmethod
+    def validate_chapter(cls, value: str) -> str:
+        """
+        Validate that the chapter field is not empty after whitespace trimming.
+
+        Parameters:
+            value (str): The chapter string from the request.
+
+        Returns:
+            str: Trimmed chapter string.
+
+        Raises:
+            ValueError: If the chapter is empty after stripping whitespace.
+        """
+        value = value.strip()
+        if not value:
+            logger.error("chapter cannot be empty")
+            raise ValueError("chapter cannot be empty")
+        return value
+
+    @field_validator("collection_name")
+    @classmethod
+    def validate_collection_name(cls, value: str) -> str:
+        """
+        Validate that the collection_name field is within the maximum length.
+
+        Parameters:
+            value (str): The collection_name string from the request.
+
+        Returns:
+            str: The validated collection_name string.
+
+        Raises:
+            ValueError: If the collection_name exceeds 3 characters.
+        """
+        if len(value) > 3:
+            raise ValueError("collection_name must be max 3 chars")
+        return value

--- a/ai/tests/views/test_devotional_chapter_view.py
+++ b/ai/tests/views/test_devotional_chapter_view.py
@@ -1,0 +1,387 @@
+"""Tests for the devotional_chapter API endpoint."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.http import HttpRequest
+from django.test import SimpleTestCase
+
+from ai.views.devotional_chapter import devotional_chapter
+
+DEFAULT_ALL_VERSES = {
+    "bsb": {
+        "Genesis": {
+            1: {
+                "1": "In the beginning God created the heavens and the earth.",
+                "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
+                "3": 'And God said, "Let there be light," and there was light.',
+                "4": "And God saw that the light was good, and He separated the light from the darkness.",
+                "5": 'God called the light "day," and the darkness He called "night." And there was evening, and there was morning—the first day.',
+            }
+        }
+    }
+}
+
+
+class TestDevotionalChapterView(SimpleTestCase):
+    """Tests for the devotional_chapter API endpoint."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.base_path = Path("ai", "llm", "prompts", "devotional_chapter")
+
+    def _call_devotional_chapter(self, request, payload):
+        """Helper to call async devotional_chapter function."""
+        return asyncio.run(devotional_chapter(request, payload))
+
+    def _build_request(self):
+        """Build a request with the required state."""
+        request = HttpRequest()
+        request.method = "POST"
+        request.state = {
+            "completions_obj": AsyncMock(),
+        }
+        return request
+
+    def _build_payload(self, book="Genesis", chapter="1", collection_name="bsb"):
+        """Build a mock payload matching DevotionalChapterInputSerializer fields."""
+        payload = MagicMock()
+        payload.book = book
+        payload.chapter = chapter
+        payload.collection_name = collection_name
+        return payload
+
+    def test_devotional_chapter_success(self):
+        """Test successful devotional_chapter endpoint with valid payload."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch("ai.views.devotional_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(
+                return_value="As you sit with Genesis 1 today, let the opening words settle over your heart."
+            )
+
+            async def mock_read(path):
+                if "system.md" in str(path):
+                    return "You are a devotional writer assistant."
+                elif "user.md" in str(path):
+                    return "Write a devotional for {book} Chapter {chapter} from {collection_name}:\n{verses}"
+                return ""
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = (
+                "<p>As you sit with Genesis 1 today, let the opening words settle over your heart.</p>"
+            )
+            mock_render.return_value = "<html>Devotional</html>"
+
+            response = self._call_devotional_chapter(request, payload)
+
+            # Verify successful response
+            assert response.status_code == 200
+            assert "text/html" in response["content-type"]
+            assert b"Devotional" in response.content
+
+            # Verify LLM completions was called
+            request.state["completions_obj"].completions.assert_called_once()
+
+    def test_devotional_chapter_calls_llm_completions(self):
+        """Test that devotional_chapter calls the LLM completions service."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch("ai.views.devotional_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Creation devotional")
+
+            async def mock_read(path):
+                if "system.md" in str(path):
+                    return "You are a devotional writer assistant."
+                elif "user.md" in str(path):
+                    return "Write a devotional for {book} Chapter {chapter} from {collection_name}:\n{verses}"
+                return ""
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = "<p>Creation devotional</p>"
+            mock_render.return_value = "Rendered template"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify LLM completions was called with proper prompts
+            request.state["completions_obj"].completions.assert_called_once()
+            call_args = request.state["completions_obj"].completions.call_args
+            # First arg is system_prompt, second is user_prompt
+            assert call_args[0][0] == "You are a devotional writer assistant."  # system prompt
+            assert "Genesis" in call_args[0][1]  # user prompt with book
+            assert "1" in call_args[0][1]  # user prompt with chapter
+            assert "bsb" in call_args[0][1]  # user prompt with collection_name
+
+    def test_devotional_chapter_loads_correct_prompt_files(self):
+        """Test that devotional_chapter loads prompts from correct file paths."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch("ai.views.devotional_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+            async def mock_read(path):
+                return "Devotional prompt"
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = "<p>Devotional</p>"
+            mock_render.return_value = "<html>Response</html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify both system and user prompts were loaded
+            assert mock_read_file.call_count == 2
+            call_paths = [call[0][0] for call in mock_read_file.call_args_list]
+            path_strings = [str(p) for p in call_paths]
+            assert any("system.md" in p for p in path_strings)
+            assert any("user.md" in p for p in path_strings)
+
+    def test_devotional_chapter_renders_template(self):
+        """Test that devotional_chapter renders the response template."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch("ai.views.devotional_chapter.ALL_VERSES", DEFAULT_ALL_VERSES),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+            async def mock_read(path):
+                return "Devotional prompt"
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = "<p>Devotional</p>"
+            mock_render.return_value = "<html><body>Response</body></html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify template rendering
+            mock_render.assert_called_once()
+            call_args = mock_render.call_args
+            assert call_args[0][0] == "partials/text.html"
+            assert call_args[0][1]["response_content"] is not None
+
+    def test_devotional_chapter_converts_chapter_to_int(self):
+        """Test that devotional_chapter converts the chapter string to an integer for ALL_VERSES lookup.
+
+        ALL_VERSES is keyed by int chapter numbers. If the string-to-int conversion were removed,
+        the lookup would raise a KeyError and completions would never be called.
+        """
+        request = self._build_request()
+        payload = self._build_payload(chapter="5")  # string — view must convert to int 5 to hit the key below
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch(
+                "ai.views.devotional_chapter.ALL_VERSES",
+                {
+                    "bsb": {
+                        "Genesis": {
+                            5: {  # int key — only reachable via int("5")
+                                "1": "This is the book of the generations of Adam.",
+                                "2": "Male and female He created them.",
+                            }
+                        }
+                    }
+                },
+            ),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+            async def mock_read(path):
+                if "user.md" in str(path):
+                    return "Write a devotional for {book} Chapter {chapter} from {collection_name}:\n{verses}"
+                return "System prompt"
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = "<p>Devotional</p>"
+            mock_render.return_value = "<html>Response</html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # If int() conversion didn't happen, ALL_VERSES["bsb"]["Genesis"]["5"] would
+            # raise KeyError and completions would never be reached.
+            request.state["completions_obj"].completions.assert_called_once()
+            call_args = request.state["completions_obj"].completions.call_args
+            user_prompt = call_args[0][1]
+            assert "Genesis" in user_prompt
+            assert "5" in user_prompt
+
+    def test_devotional_chapter_stringifies_verses(self):
+        """Test that devotional_chapter properly stringifies verses with newlines."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        verses_dict = {
+            "1": "In the beginning God created the heavens and the earth.",
+            "2": "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.",
+            "3": 'And God said, "Let there be light," and there was light.',
+        }
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch("ai.views.devotional_chapter.ALL_VERSES", {"bsb": {"Genesis": {1: verses_dict}}}),
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+            async def mock_read(path):
+                if "user.md" in str(path):
+                    return "Write a devotional for {book} Chapter {chapter} from {collection_name}:\n{verses}"
+                return "System prompt"
+
+            mock_read_file.side_effect = mock_read
+            mock_clean.return_value = "<p>Devotional</p>"
+            mock_render.return_value = "<html>Response</html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify the user prompt contains stringified verses joined with newlines
+            call_args = request.state["completions_obj"].completions.call_args
+            user_prompt = call_args[0][1]
+
+            # Should contain all three verses joined with newlines
+            assert "In the beginning God created the heavens and the earth." in user_prompt
+            assert (
+                "Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters."
+                in user_prompt
+            )
+            assert 'And God said, "Let there be light," and there was light.' in user_prompt
+
+    def test_devotional_chapter_cleans_llm_output(self):
+        """Test that devotional_chapter cleans LLM output."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch(
+                "ai.views.devotional_chapter.ALL_VERSES",
+                {"bsb": {"Genesis": {1: {"1": "In the beginning God created the heavens and the earth."}}}},
+            ),
+        ):
+            raw_output = "**Creation** devotional\n\n- Light\n- Water"
+            request.state["completions_obj"].completions = AsyncMock(return_value=raw_output)
+
+            async def mock_read(path):
+                return "Devotional prompt"
+
+            mock_read_file.side_effect = mock_read
+
+            cleaned_html = "<p><strong>Creation</strong> devotional</p><ul><li>Light</li><li>Water</li></ul>"
+            mock_clean.return_value = cleaned_html
+            mock_render.return_value = "<html>Response</html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify clean_llm_output was called with the raw output
+            mock_clean.assert_called_once_with(raw_output)
+
+    def test_devotional_chapter_marks_response_as_safe(self):
+        """Test that devotional_chapter marks HTML response as safe."""
+        request = self._build_request()
+        payload = self._build_payload()
+
+        with (
+            patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+            patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+            patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+            patch(
+                "ai.views.devotional_chapter.ALL_VERSES",
+                {"bsb": {"Genesis": {1: {"1": "In the beginning God created the heavens and the earth."}}}},
+            ),
+            patch("ai.views.devotional_chapter.mark_safe") as mock_mark_safe,
+        ):
+            request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+            async def mock_read(path):
+                return "Devotional prompt"
+
+            mock_read_file.side_effect = mock_read
+
+            cleaned_html = "<p>Devotional</p>"
+            mock_clean.return_value = cleaned_html
+            mock_mark_safe.return_value = cleaned_html
+            mock_render.return_value = "<html>Response</html>"
+
+            _ = self._call_devotional_chapter(request, payload)
+
+            # Verify mark_safe was called with cleaned HTML
+            mock_mark_safe.assert_called_once_with(cleaned_html)
+
+    def test_devotional_chapter_different_collections(self):
+        """Test that collection_name is used as the key into ALL_VERSES.
+
+        Each collection has distinct verse text; the test verifies that the correct
+        collection's verses appear in the user prompt, confirming collection_name
+        drives the lookup rather than defaulting to a fixed key.
+        """
+        collections = {
+            "bsb": "BSB-specific verse text for Genesis one.",
+            "niv": "NIV-specific verse text for Genesis one.",
+            "kjv": "KJV-specific verse text for Genesis one.",
+        }
+
+        for collection, unique_verse in collections.items():
+            with self.subTest(collection=collection):
+                request = self._build_request()
+                payload = self._build_payload(collection_name=collection)
+
+                with (
+                    patch("ai.views.devotional_chapter.async_read_file") as mock_read_file,
+                    patch("ai.views.devotional_chapter.clean_llm_output") as mock_clean,
+                    patch("ai.views.devotional_chapter.render_to_string") as mock_render,
+                    patch(
+                        "ai.views.devotional_chapter.ALL_VERSES", {collection: {"Genesis": {1: {"1": unique_verse}}}}
+                    ),
+                ):
+                    request.state["completions_obj"].completions = AsyncMock(return_value="Devotional")
+
+                    async def mock_read(path):
+                        if "user.md" in str(path):
+                            return "Write a devotional for {book} Chapter {chapter} from {collection_name}:\n{verses}"
+                        return "System prompt"
+
+                    mock_read_file.side_effect = mock_read
+                    mock_clean.return_value = "<p>Devotional</p>"
+                    mock_render.return_value = "<html>Response</html>"
+
+                    _ = self._call_devotional_chapter(request, payload)
+
+                    # Verify the verse text unique to this collection made it into the prompt,
+                    # confirming collection_name was used as the ALL_VERSES key.
+                    call_args = request.state["completions_obj"].completions.call_args
+                    user_prompt = call_args[0][1]
+                    assert unique_verse in user_prompt
+                    # Each format placeholder is interpolated into the user prompt template,
+                    # so its value must appear verbatim — guards against dropping any of them
+                    # from the format call.
+                    assert collection in user_prompt  # collection_name
+                    assert "Genesis" in user_prompt  # book
+                    assert "1" in user_prompt  # chapter

--- a/ai/tests/views/test_summarize_chapter_views.py
+++ b/ai/tests/views/test_summarize_chapter_views.py
@@ -71,7 +71,7 @@ class TestSummarizeChapterView(SimpleTestCase):
                 if "system.md" in str(path):
                     return "You are a Bible summarization assistant."
                 elif "user.md" in str(path):
-                    return "Summarize {book} Chapter {chapter}:\n{verses}"
+                    return "Summarize {book} Chapter {chapter} from {collection_name}:\n{verses}"
                 return ""
 
             mock_read_file.side_effect = mock_read
@@ -105,7 +105,7 @@ class TestSummarizeChapterView(SimpleTestCase):
                 if "system.md" in str(path):
                     return "You are a Bible summarization assistant."
                 elif "user.md" in str(path):
-                    return "Summarize {book} Chapter {chapter}:\n{verses}"
+                    return "Summarize {book} Chapter {chapter} from {collection_name}:\n{verses}"
                 return ""
 
             mock_read_file.side_effect = mock_read
@@ -121,6 +121,7 @@ class TestSummarizeChapterView(SimpleTestCase):
             assert call_args[0][0] == "You are a Bible summarization assistant."  # system prompt
             assert "Genesis" in call_args[0][1]  # user prompt with book
             assert "1" in call_args[0][1]  # user prompt with chapter
+            assert "bsb" in call_args[0][1]  # user prompt with collection_name
 
     def test_summarize_chapter_loads_correct_prompt_files(self):
         """Test that summarize_chapter loads prompts from correct file paths."""
@@ -210,7 +211,7 @@ class TestSummarizeChapterView(SimpleTestCase):
 
             async def mock_read(path):
                 if "user.md" in str(path):
-                    return "Summarize {book} Chapter {chapter}:\n{verses}"
+                    return "Summarize {book} Chapter {chapter} from {collection_name}:\n{verses}"
                 return "System prompt"
 
             mock_read_file.side_effect = mock_read
@@ -248,7 +249,7 @@ class TestSummarizeChapterView(SimpleTestCase):
 
             async def mock_read(path):
                 if "user.md" in str(path):
-                    return "Summarize {book} Chapter {chapter}:\n{verses}"
+                    return "Summarize {book} Chapter {chapter} from {collection_name}:\n{verses}"
                 return "System prompt"
 
             mock_read_file.side_effect = mock_read
@@ -360,7 +361,7 @@ class TestSummarizeChapterView(SimpleTestCase):
 
                     async def mock_read(path):
                         if "user.md" in str(path):
-                            return "Summarize {book} Chapter {chapter}:\n{verses}"
+                            return "Summarize {book} Chapter {chapter} from {collection_name}:\n{verses}"
                         return "System prompt"
 
                     mock_read_file.side_effect = mock_read
@@ -374,3 +375,9 @@ class TestSummarizeChapterView(SimpleTestCase):
                     call_args = request.state["completions_obj"].completions.call_args
                     user_prompt = call_args[0][1]
                     assert unique_verse in user_prompt
+                    # Each format placeholder is interpolated into the user prompt template,
+                    # so its value must appear verbatim — guards against dropping any of them
+                    # from the format call.
+                    assert collection in user_prompt  # collection_name
+                    assert "Genesis" in user_prompt  # book
+                    assert "1" in user_prompt  # chapter

--- a/ai/views/devotional_chapter.py
+++ b/ai/views/devotional_chapter.py
@@ -7,8 +7,8 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from ninja import Form, Router
 
+from ai.serializers.devotional_chapter import DevotionalChapterInputSerializer
 from ai.serializers.server_text_response import ServerTextResponseSerializer
-from ai.serializers.summarize_chapter import SummarizeChapterInputSerializer
 from ai.utils import async_read_file, clean_llm_output
 from fAIth.api_tags import APITags
 from fAIth.bible_globals import ALL_VERSES
@@ -16,7 +16,7 @@ from fAIth.bible_globals import ALL_VERSES
 # Set up logging
 logger = logging.getLogger(__name__)
 
-# Create router for summarize chapter API
+# Create router for devotional chapter API
 router = Router()
 
 # Configuration constants
@@ -24,15 +24,15 @@ MILVUS_SEARCH_LIMIT = int(str(os.getenv("MILVUS_SEARCH_LIMIT", 10)).strip())
 RAW_PROMPTS_DIRECTORY = Path("ai", "llm", "prompts")
 
 
-@router.post("/summarize_chapter", tags=[APITags.AI], url_name="summarize_chapter")
-async def summarize_chapter(request, payload: SummarizeChapterInputSerializer = Form(...)):
+@router.post("/devotional_chapter", tags=[APITags.AI], url_name="devotional_chapter")
+async def devotional_chapter(request, payload: DevotionalChapterInputSerializer = Form(...)):
     """
-    API endpoint for summarizing a chapter using RAG (Retrieval-Augmented Generation).
+    API endpoint for generating a devotional.
 
-    Combines vector database search with LLM completions to provide context-aware summaries.
+    Combines vector database search with LLM completions to provide context-aware devotionals.
     The workflow: validate input -> search vector DB -> load prompts -> call LLM -> render HTML response.
 
-    Process a chapter and return an LLM-generated summary.
+    Process a book and chapter and return an LLM-generated devotional.
 
     Workflow:
         1. Validate request payload (book, chapter and collection_name)
@@ -47,8 +47,8 @@ async def summarize_chapter(request, payload: SummarizeChapterInputSerializer = 
             - state["milvus_db"]: Pre-initialized vector database connection
             - state["completions_obj"]: Pre-initialized LLM completions object
         payload: Validated request payload containing:
-            - book (str): Book to summarize
-            - chapter (str): Chapter to summarize
+            - book (str): Book to generate a devotional for
+            - chapter (str): Chapter to generate a devotional for
             - collection_name (str): Milvus vector collection to search
 
     Returns:
@@ -56,7 +56,7 @@ async def summarize_chapter(request, payload: SummarizeChapterInputSerializer = 
             - 200 OK: HTML template with response_content
             - 400 Bad Request: Validation errors or missing required fields
     """
-    file_directory = "summarize_chapter"
+    file_directory = "devotional_chapter"
 
     # Extract validated data from payload
     book = payload.book

--- a/frontend/static/js/fAIth/devotional_chapter.js
+++ b/frontend/static/js/fAIth/devotional_chapter.js
@@ -1,0 +1,4 @@
+document.getElementById('devotionalChapterModal').addEventListener('show.bs.modal', function()
+{
+    document.getElementById('devotionalChapterSubmit').click();
+});

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -33,6 +33,7 @@
         {% include 'modals/inputs/general_question.html' %}
         {% include 'modals/inputs/ask_selected.html' %}
         {% include 'modals/inputs/summarize_chapter.html' %}
+        {% include 'modals/inputs/devotional_chapter.html' %}
         {% include 'modals/inputs/image_search.html' %}
         {% include 'modals/outputs/server_response.html' %}
 
@@ -44,6 +45,7 @@
         <script src="{% static 'js/fAIth/htmx_updates.js' %}"></script>
         <script src="{% static 'js/fAIth/text_selection.js' %}"></script>
         <script src="{% static 'js/fAIth/summarize_chapter.js' %}"></script>
+        <script src="{% static 'js/fAIth/devotional_chapter.js' %}"></script>
         <script src="{% static 'js/fAIth/image_search.js' %}"></script>
     </body>
 </html>

--- a/frontend/templates/modals/inputs/devotional_chapter.html
+++ b/frontend/templates/modals/inputs/devotional_chapter.html
@@ -1,0 +1,15 @@
+<div id="devotionalChapterModal" class="modal fade" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-body">
+                <form id="devotionalChapterForm" data-input-modal="devotionalChapterModal" hx-post="{% url 'api:devotional_chapter' %}" hx-target="#serverResponseContent" hx-swap="innerHTML" hx-encoding="application/x-www-form-urlencoded">
+                    {% csrf_token %}
+                    <input type="hidden" name="book" value="{{ book }}">
+                    <input type="hidden" name="chapter" value="{{ chapter }}">
+                    <input type="hidden" name="collection_name" value="{{ version }}">
+                    <button type="submit" id="devotionalChapterSubmit" style="display: none;"></button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/templates/sidebar.html
+++ b/frontend/templates/sidebar.html
@@ -16,6 +16,11 @@
                 <i class="bi bi-feather"></i>
                 <p class="mb-0" style="font-size: 0.75rem;">Summarize Chapter</p>
             </a>
+            <!-- Devotional Chapter -->
+            <a href="#" class="nav-link px-0 border-bottom" title="Devotional Chapter" data-bs-placement="right" data-bs-toggle="modal" data-bs-target="#devotionalChapterModal">
+                <i class="bi bi-bookmark-heart"></i>
+                <p class="mb-0" style="font-size: 0.75rem;">Devotional Chapter</p>
+            </a>
             {% if control_variables.SEARXNG_ENABLED %}
                 <!-- SearXNG Image Search (Enabled)-->
                 <a href="#" class="nav-link px-0 border-bottom text-highlight" aria-disabled="true" tabindex="-1" title="Image Search" data-bs-placement="right" data-bs-toggle="modal" data-bs-target="#imageSearchModal">


### PR DESCRIPTION
## Description

This PR decouples the summary and devotional aspects into their own tools. The summary aspect is strictly academic and focuses on summarizing and giving key points of a chapter. The devotional section is more personal and gives the user an in-depth chapter specific devotional complete with reflection and prayer sections.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Motivation & Context

It was requested that the devotional section in the original summary functionality should be decoupled and made its own thing.

## Testing

How have you tested this change? Please describe the test cases you've verified.

- [X] Added/updated unit tests (pytest)
- [X] Run `pytest` locally and all tests pass
- [X] Run `ruff check` and code passes linting
- [X] Run `ruff format` and code is formatted
- [X] Tested with Docker Compose setup (`docker compose up`)
- [ ] Verified database migrations (if applicable)
- [ ] Tested AI/LLM functionality (if modified)
- [ ] Verified vector database queries (if modified)
- [ ] Tested frontend changes (if applicable)
- [X] Manual testing of affected features

## Checklist

- [X] My code follows the project style guidelines (PEP 8, ruff)
- [ ] I have updated the README.md if needed
- [X] I have added/updated docstrings for new functions
- [X] I have added/updated unit tests
- [X] I have tested my changes (see Testing section)
- [X] All tests pass locally (`pytest`)
- [X] Linting passes (`ruff check`)
- [X] Formatting passes (`ruff format --check`)
- [X] I have not introduced any breaking changes without documentation

## Related Issues

N/A

## Additional Notes

N/A